### PR TITLE
Improve operation summaries and add field descriptions

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -23,7 +23,7 @@ import ballerina/http;
 public isolated client class Client {
     final http:Client clientEp;
     final readonly & ApiKeysConfig? apiKeyConfig;
-    # Gets invoked to initialize the `connector`.
+    # Gets invoked to initialize the `connector`
     #
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
@@ -39,10 +39,11 @@ public isolated client class Client {
         self.clientEp = check new (serviceUrl, httpClientConfig);
     }
 
-    # Record Participants by ContactId with Marketing Event External Ids
+    # Record participants by contact IDs
     #
     # + externalEventId - The id of the marketing event in the external event application
     # + subscriberState - The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'
+    # + payload - A batch input marketing event subscriber 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -60,7 +61,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read participations breakdown by Marketing Event internal identifier
+    # Get participations breakdown by event
     #
     # + marketingEventId - The internal id of the marketing event in HubSpot
     # + headers - Headers to be sent with the request 
@@ -77,10 +78,11 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Record a subscriber state by contact ID
+    # Record subscriber state by contact
     #
     # + externalEventId - The id of the marketing event in the external event application
     # + subscriberState - The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'
+    # + payload - A batch input marketing event subscriber 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - An error occurred 
@@ -118,6 +120,7 @@ public isolated client class Client {
     # Create or update a marketing event
     #
     # + externalEventId - The id of the marketing event in the external event application
+    # + payload - A marketing event create request params 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function putEventsExternalEventIdUpsert(string externalEventId, MarketingEventCreateRequestParams payload, map<string|string[]> headers = {}) returns MarketingEventPublicDefaultResponse|error {
@@ -133,7 +136,7 @@ public isolated client class Client {
         return self.clientEp->put(resourcePath, request, httpHeaders);
     }
 
-    # Delete Marketing Event by External Ids
+    # Delete event by external IDs
     #
     # + externalEventId - The id of the marketing event in the external event application
     # + headers - Headers to be sent with the request 
@@ -150,9 +153,10 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = httpHeaders);
     }
 
-    # Update Marketing Event by External IDs
+    # Update event by external IDs
     #
     # + externalEventId - The id of the marketing event in the external event application
+    # + payload - A marketing event update request params 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -170,8 +174,9 @@ public isolated client class Client {
         return self.clientEp->patch(resourcePath, request, httpHeaders);
     }
 
-    # Create or Update Multiple Marketing Events
+    # Upsert multiple marketing events
     #
+    # + payload - A batch input marketing event create request params 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postEventsUpsertBatchUpsert(BatchInputMarketingEventCreateRequestParams payload, map<string|string[]> headers = {}) returns BatchResponseMarketingEventPublicDefaultResponse|error {
@@ -187,10 +192,11 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Record Participants by Email with Marketing Event External Ids
+    # Record participants by email
     #
     # + externalEventId - The id of the marketing event in the external event application
     # + subscriberState - The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'
+    # + payload - A batch input marketing event email subscriber 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -208,7 +214,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read participations breakdown by Marketing Event external identifier
+    # Get participation breakdown
     #
     # + externalAccountId - The accountId that is associated with this marketing event in the external event application
     # + externalEventId - The id of the marketing event in the external event application
@@ -259,6 +265,7 @@ public isolated client class Client {
     # Update Marketing Event by objectId
     #
     # + objectId - The internal ID of the marketing event in HubSpot
+    # + payload - A marketing event public update request v2 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function patchObjectId(string objectId, MarketingEventPublicUpdateRequestV2 payload, map<string|string[]> headers = {}) returns MarketingEventPublicDefaultResponseV2|error {
@@ -274,7 +281,7 @@ public isolated client class Client {
         return self.clientEp->patch(resourcePath, request, httpHeaders);
     }
 
-    # Get lists associated with a marketing event
+    # Get event-associated lists
     #
     # + externalAccountId - The accountId that is associated with this marketing event in the external event application
     # + externalEventId - The id of the marketing event in the external event application
@@ -290,7 +297,7 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Get lists associated with a marketing event
+    # Get event-associated lists
     #
     # + marketingEventId - The internal id of the marketing event in HubSpot
     # + headers - Headers to be sent with the request 
@@ -305,10 +312,11 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Record Participants by Email with Marketing Event Object Id
+    # Record participants by email
     #
     # + objectId - The internal ID of the marketing event in HubSpot
     # + subscriberState - The attendance state value. It may be 'register', 'attend' or 'cancel'
+    # + payload - A batch input marketing event email subscriber 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postObjectIdAttendanceSubscriberStateEmailCreate(string objectId, string subscriberState, BatchInputMarketingEventEmailSubscriber payload, map<string|string[]> headers = {}) returns BatchResponseSubscriberEmailResponse|error {
@@ -340,8 +348,9 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Update Multiple Marketing Events by ObjectId
+    # Batch update events by ObjectId
     #
+    # + payload - A batch input marketing event public update request full v2 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postBatchUpdate(BatchInputMarketingEventPublicUpdateRequestFullV2 payload, map<string|string[]> headers = {}) returns BatchResponseMarketingEventPublicDefaultResponseV2|BatchResponseMarketingEventPublicDefaultResponseV2WithErrors|error {
@@ -357,10 +366,11 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Record Participants by ContactId with Marketing Event Object Id
+    # Record participants by contact ID
     #
     # + objectId - The internal id of the marketing event in HubSpot
     # + subscriberState - The attendance state value. It may be 'register', 'attend' or 'cancel'
+    # + payload - A batch input marketing event subscriber 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postObjectIdAttendanceSubscriberStateCreate(string objectId, string subscriberState, BatchInputMarketingEventSubscriber payload, map<string|string[]> headers = {}) returns BatchResponseSubscriberVidResponse|error {
@@ -376,8 +386,9 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Delete Multiple Marketing Events by ObjectId
+    # Batch delete events by ObjectId
     #
+    # + payload - A batch input marketing event public object id delete request 
     # + headers - Headers to be sent with the request 
     # + return - No content 
     remote isolated function postBatchArchive(BatchInputMarketingEventPublicObjectIdDeleteRequest payload, map<string|string[]> headers = {}) returns error? {
@@ -393,7 +404,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read participations counters by Marketing Event external identifier
+    # Get participation counters
     #
     # + externalAccountId - The accountId that is associated with this marketing event in the external event application
     # + externalEventId - The id of the marketing event in the external event application
@@ -409,7 +420,7 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Find Marketing Events by externalEventId
+    # Find events by externalEventId
     #
     # + externalEventId - The id of the marketing event in the external event application
     # + headers - Headers to be sent with the request 
@@ -424,7 +435,7 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Read participations counters by Marketing Event internal identifier
+    # Get participation counters
     #
     # + marketingEventId - The internal id of the marketing event in HubSpot
     # + headers - Headers to be sent with the request 
@@ -439,8 +450,9 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Delete Multiple Marketing Events by External Ids
+    # Batch delete by external IDs
     #
+    # + payload - A batch input marketing event external unique identifier 
     # + headers - Headers to be sent with the request 
     # + return - An error occurred 
     remote isolated function postEventsDeleteBatchArchive(BatchInputMarketingEventExternalUniqueIdentifier payload, map<string|string[]> headers = {}) returns http:Response|error {
@@ -474,7 +486,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Associate a list with a marketing event
+    # Associate list with event
     #
     # + marketingEventId - The internal id of the marketing event in HubSpot
     # + listId - The ILS ID of the list
@@ -491,7 +503,7 @@ public isolated client class Client {
         return self.clientEp->put(resourcePath, request, httpHeaders);
     }
 
-    # Disassociate a list from a marketing event
+    # Disassociate list from event
     #
     # + marketingEventId - The internal id of the marketing event in HubSpot
     # + listId - The ILS ID of the list
@@ -507,10 +519,11 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = httpHeaders);
     }
 
-    # Record a subscriber state by contact email
+    # Record subscriber state by email
     #
     # + externalEventId - The id of the marketing event in the external event application
     # + subscriberState - The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'
+    # + payload - A batch input marketing event email subscriber 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - An error occurred 
@@ -528,7 +541,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Associate a list with a marketing event
+    # Associate list with event
     #
     # + externalAccountId - The accountId that is associated with this marketing event in the external event application
     # + externalEventId - The id of the marketing event in the external event application
@@ -546,7 +559,7 @@ public isolated client class Client {
         return self.clientEp->put(resourcePath, request, httpHeaders);
     }
 
-    # Disassociate a list from a marketing event
+    # Disassociate a list from event
     #
     # + externalAccountId - The accountId that is associated with this marketing event in the external event application
     # + externalEventId - The id of the marketing event in the external event application
@@ -566,6 +579,7 @@ public isolated client class Client {
     # Mark a marketing event as completed
     #
     # + externalEventId - The id of the marketing event in the external event application
+    # + payload - A marketing event complete request params 
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -585,6 +599,7 @@ public isolated client class Client {
 
     # Create a marketing event
     #
+    # + payload - A marketing event create request params 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postEventsCreate(MarketingEventCreateRequestParams payload, map<string|string[]> headers = {}) returns MarketingEventDefaultResponse|error {
@@ -600,7 +615,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read participations breakdown by Contact identifier
+    # Get participation breakdown
     #
     # + contactIdentifier - The identifier of the Contact. It may be email or internal id
     # + headers - Headers to be sent with the request 
@@ -635,6 +650,7 @@ public isolated client class Client {
     # Update the application settings
     #
     # + appId - The id of the application to update the settings for
+    # + payload - A event detail settings url 
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     remote isolated function postAppIdSettingsUpdate(int:Signed32 appId, EventDetailSettingsUrl payload, map<string|string[]> headers = {}) returns EventDetailSettings|error {
@@ -650,7 +666,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, headers);
     }
 
-    # Find App-Specific Marketing Events by External Event Id
+    # Find events by external ID
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -31,20 +31,31 @@ public type GetParticipationsExternalAccountIdExternalEventIdBreakdownGetPartici
     string after?;
 };
 
+# Parameters required to mark a marketing event as complete, including its start and end times
 public type MarketingEventCompleteRequestParams record {
+    # The start date and time of the marketing event
     string startDateTime;
+    # The end date and time of the marketing event
     string endDateTime;
 };
 
+# Properties describing a contact's participation state and engagement in a marketing event
 public type ParticipationProperties record {
+    # Unix timestamp (ms) when the participation event occurred
     int occurredAt;
+    # Percentage of the event the contact attended
     string attendancePercentage?;
+    # Contact's attendance status: REGISTERED, ATTENDED, CANCELLED, EMPTY, or NO_SHOW
     "REGISTERED"|"ATTENDED"|"CANCELLED"|"EMPTY"|"NO_SHOW" attendanceState;
+    # Total duration in seconds the contact attended the event
     int:Signed32 attendanceDurationSeconds?;
 };
 
+# Response object containing a HubSpot contact's ID and email address
 public type SubscriberEmailResponse record {
+    # The HubSpot contact ID (VID) of the subscriber
     int vid;
+    # The email address of the subscriber
     string email;
 };
 
@@ -54,6 +65,7 @@ public type PostEventsExternalEventIdCancelCancelQueries record {
     string externalAccountId;
 };
 
+# Full details of a marketing event, including organizer info, scheduling, attendance counts, and custom properties
 public type MarketingEventPublicReadResponse record {
     # The number of HubSpot contacts that registered for this marketing event
     int:Signed32 registrants;
@@ -65,6 +77,7 @@ public type MarketingEventPublicReadResponse record {
     int:Signed32 attendees;
     # The type of the marketing event
     string eventType?;
+    # Indicates whether the marketing event has been completed
     boolean eventCompleted?;
     # The end date and time of the marketing event
     string endDateTime?;
@@ -72,10 +85,11 @@ public type MarketingEventPublicReadResponse record {
     int:Signed32 noShows;
     # The number of HubSpot contacts that registered for this marketing event, but later cancelled their registration
     int:Signed32 cancellations;
+    # Timestamp when the marketing event record was created
     string createdAt;
     # The start date and time of the marketing event
     string startDateTime?;
-    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.
+    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set
     # In order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts
     CrmPropertyWrapper[] customProperties?;
     # Indicates if the marketing event has been cancelled
@@ -86,18 +100,27 @@ public type MarketingEventPublicReadResponse record {
     string eventDescription?;
     # The name of the marketing event
     string eventName;
+    # The unique HubSpot identifier for the marketing event
     string id;
+    # The HubSpot object ID associated with the marketing event
     string objectId?;
+    # Timestamp when the marketing event record was last updated
     string updatedAt;
 };
 
+# Represents an association between a HubSpot record and a marketing event
 public type MarketingEventAssociation record {
+    # The account ID in the external event application
     string externalAccountId?;
+    # The unique identifier of the associated marketing event
     string marketingEventId;
+    # The external identifier of the associated marketing event
     string externalEventId?;
+    # The name of the associated marketing event
     string name;
 };
 
+# Detailed information about a specific error, including its message, status code, affected field, category, and contextual data
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -111,8 +134,11 @@ public type ErrorDetail record {
     string message;
 };
 
+# Represents an email-identified contact to associate with a marketing event, including their email address, subscription timestamp, and optional properties
 public type MarketingEventEmailSubscriber record {
+    # Key-value map of HubSpot contact properties to set on the contact
     record {|string...;|} contactProperties?;
+    # Key-value map of additional properties associated with the subscriber
     record {|string...;|} properties?;
     # The email address of the contact in HubSpot to associate with the event
     string email;
@@ -120,7 +146,9 @@ public type MarketingEventEmailSubscriber record {
     int interactionDateTime;
 };
 
+# Pagination metadata for forward-only traversal, containing a reference to the next page of results
 public type ForwardPaging record {
+    # Pagination cursor object used to retrieve the next page of results
     NextPage next?;
 };
 
@@ -130,19 +158,33 @@ public type PostEventsExternalEventIdCompleteCompleteQueries record {
     string externalAccountId;
 };
 
+# Represents a HubSpot list, including its identifier, name, object type, processing configuration, membership size, and audit timestamps
 public type PublicList record {
+    # The processing method used to evaluate list membership
     string processingType;
+    # The type identifier of objects contained in the list
     string objectTypeId;
+    # The ID of the user who last updated the list
     string updatedById?;
+    # Timestamp when the list's filter criteria were last updated
     string filtersUpdatedAt?;
+    # The unique identifier of the list
     string listId;
+    # Timestamp when the list was created
     string createdAt?;
+    # The current processing status of the list
     string processingStatus;
+    # Timestamp when the list was deleted, if applicable
     string deletedAt?;
+    # The version number of the list
     int:Signed32 listVersion;
+    # The total number of members in the list
     int size?;
+    # The display name of the list
     string name;
+    # The ID of the user who created the list
     string createdById?;
+    # Timestamp of the most recent update to the list
     string updatedAt?;
 };
 
@@ -152,6 +194,7 @@ public type PatchEventsExternalEventIdUpdateQueries record {
     string externalAccountId;
 };
 
+# Uniquely identifies a marketing event across the external application, HubSpot app, and account
 public type MarketingEventExternalUniqueIdentifier record {
     # The accountId that is associated with this marketing event in the external event application
     string externalAccountId;
@@ -161,15 +204,18 @@ public type MarketingEventExternalUniqueIdentifier record {
     int:Signed32 appId;
 };
 
+# A name-value pair representing a custom CRM property on a marketing event
 public type CrmPropertyWrapper record {
+    # The internal name of the CRM property
     string name;
+    # The value assigned to the CRM property
     string value;
 };
 
-# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
+# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
-    # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
+    # Provides Auth configurations needed when communicating with a remote HTTP endpoint
     http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
     # The HTTP version understood by the client
     http:HttpVersion httpVersion = http:HTTP_2_0;
@@ -206,17 +252,23 @@ public type ConnectionConfig record {|
     # Enables the inbound payload validation functionality which provided by the constraint package. Enabled by default
     boolean validation = true;
     # Enables relaxed data binding on the client side. When enabled, `nil` values are treated as optional, 
-    # and absent fields are handled as `nilable` types. Enabled by default.
+    # and absent fields are handled as `nilable` types. Enabled by default
     boolean laxDataBinding = true;
 |};
 
+# Represents a search result identifying a marketing event by its external and HubSpot object identifiers
 public type SearchPublicResponseWrapper record {
+    # The account ID from the external event application
     string externalAccountId;
+    # The event ID from the external event application
     string externalEventId;
+    # The ID of the app that created the marketing event
     int:Signed32 appId;
+    # The HubSpot object ID of the marketing event
     string objectId;
 };
 
+# Contains the HubSpot contact visitor ID returned after a subscriber operation
 public type SubscriberVidResponse record {
     int vid;
 };
@@ -233,34 +285,53 @@ public type GetParticipationsMarketingEventIdBreakdownGetParticipationsBreakdown
     string after?;
 };
 
+# Request payload for partially updating an existing marketing event's details and custom properties
 public type MarketingEventPublicUpdateRequestV2 record {
+    # The scheduled start date and time of the marketing event
     string startDateTime?;
+    # A list of custom CRM properties to associate with the marketing event
     CrmPropertyWrapper[] customProperties;
+    # Indicates whether the marketing event has been cancelled
     boolean eventCancelled?;
+    # The name of the organizer responsible for the event
     string eventOrganizer?;
+    # The URL of the marketing event's landing or registration page
     string eventUrl?;
+    # A text description providing details about the marketing event
     string eventDescription?;
+    # The name of the marketing event
     string eventName?;
+    # The type of event (e.g., WEBINAR, CONFERENCE, WORKSHOP)
     string eventType?;
+    # The end date and time of the marketing event
     string endDateTime?;
 };
 
+# Response object containing identifiers that uniquely reference a marketing event, including its external ID, HubSpot object ID, and associated app info
 public type MarketingEventIdentifiersResponse record {
+    # The external account ID associated with the marketing event
     string externalAccountId?;
+    # The unique identifier of the event in the external application
     string externalEventId;
+    # Object containing identifying information about the application associated with a marketing event
     AppInfo appInfo?;
+    # The HubSpot object ID of the marketing event
     string objectId;
+    # The name of the marketing event
     string marketingEventName;
 };
 
+# Batch input object containing a list of external unique identifiers for marketing events
 public type BatchInputMarketingEventExternalUniqueIdentifier record {
+    # A list of external unique identifiers for the marketing events
     MarketingEventExternalUniqueIdentifier[] inputs;
 };
 
+# Request parameters for updating an existing marketing event, including scheduling, organizer details, custom properties, and status flags
 public type MarketingEventUpdateRequestParams record {
     # The start date and time of the marketing event
     string startDateTime?;
-    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.
+    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set
     # In order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts
     CrmPropertyWrapper[] customProperties?;
     # Indicates if the marketing event has been cancelled. Defaults to `false`
@@ -275,18 +346,25 @@ public type MarketingEventUpdateRequestParams record {
     string eventName?;
     # Describes what type of event this is.  For example: `WEBINAR`, `CONFERENCE`, `WORKSHOP`
     string eventType?;
+    # Indicates whether the marketing event has been completed
     boolean eventCompleted?;
     # The end date and time of the marketing event
     string endDateTime?;
 };
 
+# Object containing identifying information about the application associated with a marketing event
 public type AppInfo record {
+    # The name of the application
     string name;
+    # The unique identifier of the application
     string id;
 };
 
+# A collection response containing a total count and an array of public lists, returned without paging metadata
 public type CollectionResponseWithTotalPublicListNoPaging record {
+    # The total number of results in the collection
     int:Signed32 total;
+    # The array of public list objects returned in the response
     PublicList[] results;
 };
 
@@ -296,17 +374,27 @@ public type DeleteEventsExternalEventIdArchiveQueries record {
     string externalAccountId;
 };
 
+# Represents a contact association for a marketing event, linking a contact by ID and email along with optional name details
 public type ContactAssociation record {
+    # The contact's first name
     string firstname?;
+    # The unique identifier of the associated contact
     string contactId;
+    # The email address of the associated contact
     string email;
+    # The contact's last name
     string lastname?;
 };
 
+# Detailed breakdown of a contact's participation in a marketing event, including associations, timestamps, and properties
 public type ParticipationBreakdown record {
+    # Defines the associations between a contact and a marketing event for participation tracking
     ParticipationAssociations associations;
+    # The datetime when the participation record was created
     string createdAt;
+    # The unique identifier of the participation record
     string id;
+    # Properties describing a contact's participation state and engagement in a marketing event
     ParticipationProperties properties;
 };
 
@@ -316,6 +404,7 @@ public type GetEventsSearchDoSearchQueries record {
     string q;
 };
 
+# Default response object representing a marketing event, including its details, status, and custom properties
 public type MarketingEventPublicDefaultResponse record {
     # The name of the organizer of the marketing event
     string eventOrganizer;
@@ -323,13 +412,15 @@ public type MarketingEventPublicDefaultResponse record {
     string eventUrl?;
     # The type of the marketing event
     string eventType?;
+    # Indicates whether the marketing event has been completed
     boolean eventCompleted?;
     # The end date and time of the marketing event
     string endDateTime?;
+    # The datetime when the marketing event record was created
     string createdAt;
     # The start date and time of the marketing event
     string startDateTime?;
-    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.
+    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set
     # In order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts
     CrmPropertyWrapper[] customProperties?;
     # Indicates if the marketing event has been cancelled
@@ -338,26 +429,39 @@ public type MarketingEventPublicDefaultResponse record {
     string eventDescription?;
     # The name of the marketing event
     string eventName;
+    # The unique identifier of the marketing event
     string id;
+    # The HubSpot object ID associated with the marketing event
     string objectId?;
+    # The datetime when the marketing event record was last updated
     string updatedAt;
 };
 
+# Batch response containing subscriber VID results, processing status, error counts, and timestamps
 public type BatchResponseSubscriberVidResponse record {
+    # The datetime when the batch operation completed
     string completedAt;
+    # The total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
+    # The datetime when the batch operation was requested
     string requestedAt?;
+    # The datetime when the batch operation started processing
     string startedAt;
+    # Map of related resource links for the batch response
     record {|string...;|} links?;
+    # List of subscriber VID responses returned in the batch
     SubscriberVidResponse[] results;
+    # List of errors encountered during batch processing
     StandardError[] errors?;
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Default response schema representing a marketing event, including its name, organizer, dates, type, description, URL, and optional custom properties
 public type MarketingEventDefaultResponse record {
     # The start date and time of the marketing event
     string startDateTime?;
-    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.
+    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set
     # In order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts
     CrmPropertyWrapper[] customProperties?;
     # Indicates if the marketing event has been cancelled
@@ -372,23 +476,29 @@ public type MarketingEventDefaultResponse record {
     string eventName;
     # The type of the marketing event
     string eventType?;
+    # Indicates whether the marketing event has been completed
     boolean eventCompleted?;
     # The end date and time of the marketing event
     string endDateTime?;
+    # The HubSpot object ID of the marketing event
     string objectId?;
 };
 
+# Defines the associations between a contact and a marketing event for participation tracking
 public type ParticipationAssociations record {
+    # Represents an association between a HubSpot record and a marketing event
     MarketingEventAssociation marketingEvent;
+    # Represents a contact association for a marketing event, linking a contact by ID and email along with optional name details
     ContactAssociation contact;
 };
 
+# Batch input schema containing a list of HubSpot contacts to subscribe to a marketing event
 public type BatchInputMarketingEventSubscriber record {
     # List of HubSpot contacts to subscribe to the marketing event
     MarketingEventSubscriber[] inputs;
 };
 
-# Provides API key configurations needed when communicating with a remote HTTP endpoint.
+# Provides API key configurations needed when communicating with a remote HTTP endpoint
 public type ApiKeysConfig record {|
     string hapikey;
     string privateAppLegacy;
@@ -400,21 +510,31 @@ public type GetEventsExternalEventIdGetDetailsQueries record {
     string externalAccountId;
 };
 
+# Standard error response schema containing status, category, message, context, and error details
 public type StandardError record {
+    # Optional sub-category providing additional error classification
     record {} subCategory?;
+    # Key-value map of contextual details related to the error
     record {|string[]...;|} context;
+    # Map of relevant links associated with the error
     record {|string...;|} links;
+    # Unique identifier for the error instance
     string id?;
+    # High-level category classifying the type of error
     string category;
+    # Human-readable message describing the error
     string message;
+    # List of detailed error entries associated with this error
     ErrorDetail[] errors;
+    # HTTP status or error state associated with this error
     string status;
 };
 
+# Request parameters for creating a new marketing event, including required identifiers, organizer details, scheduling, and optional custom properties
 public type MarketingEventCreateRequestParams record {
     # The start date and time of the marketing event
     string startDateTime?;
-    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.
+    # A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set
     # In order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts
     CrmPropertyWrapper[] customProperties?;
     # The accountId that is associated with this marketing event in the external event application
@@ -433,20 +553,27 @@ public type MarketingEventCreateRequestParams record {
     string eventName;
     # Describes what type of event this is.  For example: `WEBINAR`, `CONFERENCE`, `WORKSHOP`
     string eventType?;
+    # Indicates whether the marketing event has been completed
     boolean eventCompleted?;
     # The end date and time of the marketing event
     string endDateTime?;
 };
 
+# Batch request payload containing a list of marketing events to update in bulk
 public type BatchInputMarketingEventPublicUpdateRequestFullV2 record {
+    # List of marketing event update requests to process in the batch
     MarketingEventPublicUpdateRequestFullV2[] inputs;
 };
 
+# A collection response containing marketing event identifiers along with the total count of results
 public type CollectionResponseWithTotalMarketingEventIdentifiersResponseNoPaging record {
+    # Total number of marketing event identifier results returned
     int:Signed32 total;
+    # List of marketing event identifier response objects
     MarketingEventIdentifiersResponse[] results;
 };
 
+# Configuration settings for an application's marketing event detail URL, keyed by app ID
 public type EventDetailSettings record {
     # The id of the application the settings are for
     int:Signed32 appId;
@@ -454,8 +581,11 @@ public type EventDetailSettings record {
     string eventDetailsUrl;
 };
 
+# Represents a contact subscriber for a marketing event, including their ID, interaction timestamp, and additional properties
 public type MarketingEventSubscriber record {
+    # The HubSpot contact ID (vid) of the event subscriber
     int vid;
+    # Additional key-value properties associated with the subscriber
     record {|string...;|} properties?;
     # Timestamp in milliseconds at which the contact subscribed to the event
     int interactionDateTime;
@@ -467,6 +597,7 @@ public type PostAttendanceExternalEventIdSubscriberStateCreateRecordByContactIds
     string externalAccountId?;
 };
 
+# Defines the URL template used to fetch marketing event details by ID, requiring a `%s` placeholder for the event ID
 public type EventDetailSettingsUrl record {
     # The url that will be used to fetch marketing event details by id. Must contain a `%s` character sequence that will be substituted with the event id. For example: `https://my.event.app/events/%s`
     string eventDetailsUrl;
@@ -482,30 +613,49 @@ public type GetParticipationsContactsContactIdentifierBreakdownGetParticipations
     string after?;
 };
 
+# Batch request payload containing a list of marketing event email subscriber records to create or update
 public type BatchInputMarketingEventEmailSubscriber record {
     # List of marketing event details to create or update
     MarketingEventEmailSubscriber[] inputs;
 };
 
+# Default response object for a marketing event (V2), including event details, scheduling, status flags, and custom properties
 public type MarketingEventPublicDefaultResponseV2 record {
+    # The name of the organizer of the marketing event
     string eventOrganizer?;
+    # URL to the event in the external event application
     string eventUrl?;
+    # Object containing identifying information about the application associated with a marketing event
     AppInfo appInfo?;
+    # The type or category of the marketing event
     string eventType?;
+    # Indicates whether the marketing event has completed
     boolean eventCompleted?;
+    # The date and time when the marketing event ends
     string endDateTime?;
+    # The date and time when the marketing event was created
     string createdAt;
+    # The date and time when the marketing event starts
     string startDateTime?;
+    # A list of custom CRM properties associated with the marketing event
     CrmPropertyWrapper[] customProperties;
+    # Indicates whether the marketing event has been cancelled
     boolean eventCancelled?;
+    # A text description providing details about the marketing event
     string eventDescription?;
+    # The name or title of the marketing event
     string eventName;
+    # The unique identifier of the marketing event object
     string objectId;
+    # The date and time when the marketing event was last updated
     string updatedAt;
 };
 
+# A paginated collection response containing a list of marketing event read responses with optional forward paging details
 public type CollectionResponseMarketingEventPublicReadResponseV2ForwardPaging record {
+    # Pagination metadata for forward-only traversal, containing a reference to the next page of results
     ForwardPaging paging?;
+    # List of marketing event public read response objects (V2)
     MarketingEventPublicReadResponseV2[] results;
 };
 
@@ -522,80 +672,141 @@ public type PostEventsExternalEventIdSubscriberStateUpsertUpsertByContactIdQueri
     string externalAccountId;
 };
 
+# Request body schema for performing a full update of an existing marketing event, including all updatable fields and custom properties
 public type MarketingEventPublicUpdateRequestFullV2 record {
+    # The date and time when the marketing event starts
     string startDateTime?;
+    # A list of custom CRM properties to associate with the marketing event
     CrmPropertyWrapper[] customProperties;
+    # Set to true to mark the marketing event as cancelled
     boolean eventCancelled?;
+    # The name or identifier of the event organizer
     string eventOrganizer?;
+    # The URL linking to the marketing event's page or registration
     string eventUrl?;
+    # A text description providing details about the marketing event
     string eventDescription?;
+    # The name or title of the marketing event
     string eventName?;
+    # The type or category of the marketing event
     string eventType?;
+    # The scheduled end date and time of the marketing event
     string endDateTime?;
+    # The unique identifier of the marketing event object
     string objectId;
 };
 
+# Represents the full read response for a marketing event, including metadata, scheduling, attendance statistics, and custom properties
 public type MarketingEventPublicReadResponseV2 record {
+    # The total number of contacts registered for the event
     int:Signed32 registrants?;
+    # The name of the person or organization hosting the event
     string eventOrganizer?;
+    # The URL where the marketing event can be accessed or viewed
     string eventUrl?;
+    # The total number of contacts who attended the event
     int:Signed32 attendees?;
+    # Object containing identifying information about the application associated with a marketing event
     AppInfo appInfo?;
+    # The category or format type of the marketing event
     string eventType?;
+    # Indicates whether the marketing event has been completed
     boolean eventCompleted?;
+    # The date and time when the marketing event ends
     string endDateTime?;
+    # The number of registered contacts who did not attend the event
     int:Signed32 noShows?;
+    # The total number of registrations cancelled for the event
     int:Signed32 cancellations?;
+    # The date and time when the marketing event record was created
     string createdAt;
+    # The date and time when the marketing event begins
     string startDateTime?;
+    # A list of custom CRM properties associated with the marketing event
     CrmPropertyWrapper[] customProperties;
+    # Indicates whether the marketing event has been cancelled
     boolean eventCancelled?;
+    # The unique identifier of the event in the external source system
     string externalEventId?;
+    # The current status of the marketing event
     string eventStatus?;
+    # A text description providing details about the marketing event
     string eventDescription?;
+    # The name of the marketing event
     string eventName;
+    # The unique identifier of the marketing event object
     string objectId;
+    # The datetime the marketing event was last updated
     string updatedAt;
 };
 
+# A batch input object containing an array of marketing event creation request parameters
 public type BatchInputMarketingEventCreateRequestParams record {
+    # An array of marketing event creation request parameter objects
     MarketingEventCreateRequestParams[] inputs;
 };
 
+# A batch response object containing results, status, timing metadata, and any errors encountered during processing of marketing events
 public type BatchResponseMarketingEventPublicDefaultResponseV2WithErrors record {
+    # The datetime the batch operation completed
     string completedAt;
+    # The total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
+    # The datetime the batch operation was requested
     string requestedAt?;
+    # The datetime the batch operation started processing
     string startedAt;
+    # A map of relevant link names to associated URIs
     record {|string...;|} links?;
+    # An array of successfully processed marketing event response objects
     MarketingEventPublicDefaultResponseV2[] results;
+    # An array of standard error objects for any failed items in the batch
     StandardError[] errors?;
+    # The current status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A batch input object containing an array of marketing event object ID delete requests
 public type BatchInputMarketingEventPublicObjectIdDeleteRequest record {
+    # An array of marketing event object ID delete request objects
     MarketingEventPublicObjectIdDeleteRequest[] inputs;
 };
 
+# A collection response containing an array of search result wrapper objects with no paging information
 public type CollectionResponseSearchPublicResponseWrapperNoPaging record {
+    # An array of search result wrapper objects returned by the query
     SearchPublicResponseWrapper[] results;
 };
 
+# Batch response containing subscriber email operation results, status, timing metadata, and any errors encountered
 public type BatchResponseSubscriberEmailResponse record {
+    # Timestamp when the batch operation completed
     string completedAt;
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
+    # Timestamp when the batch operation was requested
     string requestedAt?;
+    # Timestamp when the batch operation began processing
     string startedAt;
+    # Map of relevant navigational links related to the batch response
     record {|string...;|} links?;
+    # List of subscriber email responses returned by the batch operation
     SubscriberEmailResponse[] results;
+    # List of errors encountered during the batch operation
     StandardError[] errors?;
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# An object containing attendance count totals for a marketing event, including registered, attended, cancelled, and no-show figures
 public type AttendanceCounters record {
+    # Number of contacts who attended the event
     int:Signed32 attended;
+    # Number of contacts registered for the event
     int:Signed32 registered;
+    # Number of contacts who cancelled their registration
     int:Signed32 cancelled;
+    # Number of registered contacts who did not attend
     int:Signed32 noShows;
 };
 
@@ -605,22 +816,35 @@ public type PostAttendanceExternalEventIdSubscriberStateEmailCreateRecordByConta
     string externalAccountId?;
 };
 
+# Request body for deleting a marketing event identified by its object ID
 public type MarketingEventPublicObjectIdDeleteRequest record {
+    # The unique identifier of the marketing event to delete
     string objectId;
 };
 
+# Paginated collection of participation breakdown records with a total count
 public type CollectionResponseWithTotalParticipationBreakdownForwardPaging record {
+    # Total number of participation breakdown records available
     int:Signed32 total;
+    # Pagination metadata for forward-only traversal, containing a reference to the next page of results
     ForwardPaging paging?;
+    # List of participation breakdown records for the current page
     ParticipationBreakdown[] results;
 };
 
+# Batch response containing marketing event results, processing status, and timing metadata
 public type BatchResponseMarketingEventPublicDefaultResponseV2 record {
+    # Timestamp when the batch request completed
     string completedAt;
+    # Timestamp when the batch request was received
     string requestedAt?;
+    # Timestamp when the batch request began processing
     string startedAt;
+    # Map of relevant navigation links for the batch response
     record {|string...;|} links?;
+    # List of marketing event results returned by the batch operation
     MarketingEventPublicDefaultResponseV2[] results;
+    # Current processing status of the batch request
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
@@ -632,19 +856,31 @@ public type GetQueries record {
     string after?;
 };
 
+# Pagination cursor object used to retrieve the next page of results
 public type NextPage record {
+    # URL link to the next page of results
     string link?;
+    # Cursor token identifying the start of the next results page
     string after;
 };
 
+# Batch response containing marketing event results, status, and error details
 public type BatchResponseMarketingEventPublicDefaultResponse record {
+    # Timestamp when the batch request completed
     string completedAt;
+    # Total number of errors encountered in the batch request
     int:Signed32 numErrors?;
+    # Timestamp when the batch request was received
     string requestedAt?;
+    # Timestamp when the batch request began processing
     string startedAt;
+    # Map of relevant navigation links for the batch response
     record {|string...;|} links?;
+    # List of marketing event results returned by the batch operation
     MarketingEventPublicDefaultResponse[] results;
+    # List of errors encountered during batch processing
     StandardError[] errors?;
+    # Current processing status of the batch request
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 

--- a/docs/spec/aligned_ballerina_openapi.json
+++ b/docs/spec/aligned_ballerina_openapi.json
@@ -1,0 +1,4185 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Marketing Events",
+        "version": "v3",
+        "x-hubspot-product-tier-requirements": {
+            "marketing": "FREE",
+            "cms": "STARTER"
+        },
+        "x-hubspot-documentation-banner": "PUBLIC_BETA",
+        "x-hubspot-api-use-case": "You have an external system that handles registration for your webinars and you want to ensure that attendee data and behavior is synced with your HubSpot CRM.",
+        "x-hubspot-related-documentation": [
+            {
+                "name": "Marketing Events Guide",
+                "url": "https://developers.hubspot.com/beta-docs/guides/api/marketing/marketing-events"
+            }
+        ],
+        "x-hubspot-introduction": "A marketing event is a CRM object, similar to contacts and companies, that enables you to track marketing events, such as a webinar, along with the contacts who registered and attended the event. Below, learn more about working with the marketing event API to integrate marketing events into an app."
+    },
+    "servers": [
+        {
+            "url": "https://api.hubapi.com/marketing/v3/marketing-events"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Add event attendees"
+        },
+        {
+            "name": "Retrieve Participant State"
+        },
+        {
+            "name": "Subscriber State Changes"
+        },
+        {
+            "name": "Basic"
+        },
+        {
+            "name": "Batch"
+        },
+        {
+            "name": "List Associations"
+        },
+        {
+            "name": "Identifiers"
+        },
+        {
+            "name": "Change property"
+        },
+        {
+            "name": "Settings"
+        }
+    ],
+    "paths": {
+        "/attendance/{externalEventId}/{subscriberState}/create": {
+            "post": {
+                "tags": [
+                    "Add event attendees"
+                ],
+                "summary": "Record participants by contact IDs",
+                "description": "Records the participation of multiple HubSpot contacts in a Marketing Event using their HubSpot contact IDs.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+                "operationId": "post-/attendance/{externalEventId}/{subscriberState}/create_recordByContactIds",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subscriberState",
+                        "in": "path",
+                        "description": "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventSubscriber"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSubscriberVidResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/participations/{marketingEventId}/breakdown": {
+            "get": {
+                "tags": [
+                    "Retrieve Participant State"
+                ],
+                "summary": "Get participations breakdown by event",
+                "description": "Read Marketing event's participations breakdown with optional filters by internal identifier marketingEventId.",
+                "operationId": "get-/participations/{marketingEventId}/breakdown_getParticipationsBreakdownByMarketingEventId",
+                "parameters": [
+                    {
+                        "name": "marketingEventId",
+                        "in": "path",
+                        "description": "The internal id of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "contactIdentifier",
+                        "in": "query",
+                        "description": "The identifier of the Contact. It may be email or internal id",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "description": "The participation state value. It may be REGISTERED, CANCELLED, ATTENDED, NO_SHOW",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The limit for response size. The default value is 10, the max number is 100",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The cursor indicating the position of the last retrieved item",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalParticipationBreakdownForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/{externalEventId}/{subscriberState}/upsert": {
+            "post": {
+                "tags": [
+                    "Subscriber State Changes"
+                ],
+                "summary": "Record subscriber state by contact",
+                "description": "Record a subscriber state between multiple HubSpot contacts and a marketing event, using HubSpot contact IDs. Note that the contact must already exist in HubSpot; a contact will not be created.",
+                "operationId": "post-/events/{externalEventId}/{subscriberState}/upsert_upsertByContactId",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subscriberState",
+                        "in": "path",
+                        "description": "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventSubscriber"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/{externalEventId}": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Get Marketing Event by External IDs",
+                "description": "Returns the details of a Marketing Event with the specified externalAccountId, externalEventId, if it exists.\n\nOnly Marketing Events created by the same app making the request can be retrieved.",
+                "operationId": "get-/events/{externalEventId}_getDetails",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventPublicReadResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Create or update a marketing event",
+                "description": "Upserts a marketing event If there is an existing marketing event with the specified ID, it will be updated; otherwise a new event will be created.",
+                "operationId": "put-/events/{externalEventId}_upsert",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarketingEventCreateRequestParams"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventPublicDefaultResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Delete event by external IDs",
+                "description": "Deletes the existing Marketing Event with the specified externalAccountId, externalEventId, if it exists.\n\nOnly Marketing Events created by the same app can be deleted.",
+                "operationId": "delete-/events/{externalEventId}_archive",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Update event by external IDs",
+                "description": "Updates the details of an existing Marketing Event identified by its externalAccountId, externalEventId if it exists.\n\nOnly Marketing Events created by the same app can be updated.",
+                "operationId": "patch-/events/{externalEventId}_update",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarketingEventUpdateRequestParams"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventPublicDefaultResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/upsert": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Upsert multiple marketing events",
+                "description": "Upserts multiple Marketing Events. If a Marketing Event with the specified ID already exists, it will be updated; otherwise, a new event will be created.\n\nOnly Marketing Events originally created by the same app can be updated.",
+                "operationId": "post-/events/upsert_batchUpsert",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventCreateRequestParams"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseMarketingEventPublicDefaultResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/attendance/{externalEventId}/{subscriberState}/email-create": {
+            "post": {
+                "tags": [
+                    "Add event attendees"
+                ],
+                "summary": "Record participants by email",
+                "description": "Records the participation of multiple HubSpot contacts in a Marketing Event using their email addresses.\n\nIf a contact does not exist, it will be automatically created. The contactProperties field is used exclusively for creating new contacts and will not update properties of existing contacts.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+                "operationId": "post-/attendance/{externalEventId}/{subscriberState}/email-create_recordByContactEmails",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subscriberState",
+                        "in": "path",
+                        "description": "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventEmailSubscriber"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSubscriberEmailResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/participations/{externalAccountId}/{externalEventId}/breakdown": {
+            "get": {
+                "tags": [
+                    "Retrieve Participant State"
+                ],
+                "summary": "Get participation breakdown",
+                "description": "Read Marketing event's participations breakdown with optional filters by externalAccountId and externalEventId pair.",
+                "operationId": "get-/participations/{externalAccountId}/{externalEventId}/breakdown_getParticipationsBreakdownByExternalEventId",
+                "parameters": [
+                    {
+                        "name": "externalAccountId",
+                        "in": "path",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "contactIdentifier",
+                        "in": "query",
+                        "description": "The identifier of the Contact. It may be email or internal id",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "description": "The participation state value. It may be REGISTERED, CANCELLED, ATTENDED, NO_SHOW",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The limit for response size. The default value is 10, the max number is 100",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The cursor indicating the position of the last retrieved item",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalParticipationBreakdownForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/{objectId}": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Get Marketing Event by objectId",
+                "description": "Returns the details of a Marketing Event with the specified objectId, if it exists.",
+                "operationId": "get-/{objectId}",
+                "parameters": [
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "description": "The internal ID of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventPublicReadResponseV2"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Delete Marketing Event by objectId",
+                "description": "Deletes the existing Marketing Event with the specified objectId, if it exists.",
+                "operationId": "delete-/{objectId}",
+                "parameters": [
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "description": "The internal ID of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Update Marketing Event by objectId",
+                "description": "Updates the details of an existing Marketing Event identified by its objectId, if it exists.",
+                "operationId": "patch-/{objectId}",
+                "parameters": [
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "description": "The internal ID of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarketingEventPublicUpdateRequestV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventPublicDefaultResponseV2"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/associations/{externalAccountId}/{externalEventId}/lists": {
+            "get": {
+                "tags": [
+                    "List Associations"
+                ],
+                "summary": "Get event-associated lists",
+                "description": "Gets lists associated with a marketing event by external account id and external event id",
+                "operationId": "get-/associations/{externalAccountId}/{externalEventId}/lists_getAllByExternalAccountAndEventIds",
+                "parameters": [
+                    {
+                        "name": "externalAccountId",
+                        "in": "path",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalPublicListNoPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/associations/{marketingEventId}/lists": {
+            "get": {
+                "tags": [
+                    "List Associations"
+                ],
+                "summary": "Get event-associated lists",
+                "description": "Gets lists associated with a marketing event by marketing event id",
+                "operationId": "get-/associations/{marketingEventId}/lists_getAllByMarketingEventId",
+                "parameters": [
+                    {
+                        "name": "marketingEventId",
+                        "in": "path",
+                        "description": "The internal id of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalPublicListNoPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/{objectId}/attendance/{subscriberState}/email-create": {
+            "post": {
+                "tags": [
+                    "Add event attendees"
+                ],
+                "summary": "Record participants by email",
+                "description": "Records the participation of multiple HubSpot contacts in a Marketing Event using their email addresses.\n\nIf a contact does not exist, it will be automatically created. The contactProperties field is used exclusively for creating new contacts and will not update properties of existing contacts.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+                "operationId": "post-/{objectId}/attendance/{subscriberState}/email-create",
+                "parameters": [
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "description": "The internal ID of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subscriberState",
+                        "in": "path",
+                        "description": "The attendance state value. It may be 'register', 'attend' or 'cancel'",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventEmailSubscriber"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSubscriberEmailResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Get all marketing event",
+                "description": "Returns all Marketing Events available on the portal, along with their properties, regardless of whether they were created manually or through the application.\n\nThe marketing events returned by this endpoint are sorted by objectId.",
+                "operationId": "get-/",
+                "parameters": [
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The cursor indicating the position of the last retrieved item",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The limit for response size. The default value is 10, the max number is 100",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseMarketingEventPublicReadResponseV2ForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/update": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Batch update events by ObjectId",
+                "description": "Updates multiple Marketing Events on the portal based on their objectId, if they exist.",
+                "operationId": "post-/batch/update",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventPublicUpdateRequestFullV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseMarketingEventPublicDefaultResponseV2"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseMarketingEventPublicDefaultResponseV2WithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/{objectId}/attendance/{subscriberState}/create": {
+            "post": {
+                "tags": [
+                    "Add event attendees"
+                ],
+                "summary": "Record participants by contact ID",
+                "description": "Records the participation of multiple HubSpot contacts in a Marketing Event using their HubSpot contact IDs.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+                "operationId": "post-/{objectId}/attendance/{subscriberState}/create",
+                "parameters": [
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "description": "The internal id of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subscriberState",
+                        "in": "path",
+                        "description": "The attendance state value. It may be 'register', 'attend' or 'cancel'",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventSubscriber"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSubscriberVidResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/archive": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Batch delete events by ObjectId",
+                "description": "Deletes multiple Marketing Events from the portal based on their objectId, if they exist.\n\nResponses:\n204: Returned if all specified Marketing Events were successfully deleted.\n207: Returned if some objectIds did not correspond to any existing Marketing Events.",
+                "operationId": "post-/batch/archive",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventPublicObjectIdDeleteRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/participations/{externalAccountId}/{externalEventId}": {
+            "get": {
+                "tags": [
+                    "Retrieve Participant State"
+                ],
+                "summary": "Get participation counters",
+                "description": "Read Marketing event's participations counters by externalAccountId and externalEventId pair.",
+                "operationId": "get-/participations/{externalAccountId}/{externalEventId}_getParticipationsCountersByEventExternalId",
+                "parameters": [
+                    {
+                        "name": "externalAccountId",
+                        "in": "path",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AttendanceCounters"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/{externalEventId}/identifiers": {
+            "get": {
+                "tags": [
+                    "Identifiers"
+                ],
+                "summary": "Find events by externalEventId",
+                "description": "This endpoint searches the portal for all Marketing Events whose externalEventId matches the value provided in the request.\n\nIt retrieves the objectId and additional event details for each matching Marketing Event.\n\nSince multiple Marketing Events can have the same externalEventId, the endpoint returns all matching results.\n\nNote: Marketing Events become searchable by externalEventId a few minutes after creation.",
+                "operationId": "get-/{externalEventId}/identifiers",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalMarketingEventIdentifiersResponseNoPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/participations/{marketingEventId}": {
+            "get": {
+                "tags": [
+                    "Retrieve Participant State"
+                ],
+                "summary": "Get participation counters",
+                "description": "Read Marketing event's participations counters by internal identifier marketingEventId.",
+                "operationId": "get-/participations/{marketingEventId}_getParticipationsCountersByMarketingEventId",
+                "parameters": [
+                    {
+                        "name": "marketingEventId",
+                        "in": "path",
+                        "description": "The internal id of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AttendanceCounters"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/delete": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Batch delete by external IDs",
+                "description": "Deletes multiple Marketing Events based on externalAccountId, externalEventId, and appId.\n\nOnly Marketing Events created by the same apps will be deleted; events from other apps cannot be removed by this endpoint. ",
+                "operationId": "post-/events/delete_batchArchive",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventExternalUniqueIdentifier"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/{externalEventId}/cancel": {
+            "post": {
+                "tags": [
+                    "Change property"
+                ],
+                "summary": "Mark a marketing event as cancelled",
+                "description": "Mark a marketing event as cancelled.",
+                "operationId": "post-/events/{externalEventId}/cancel_cancel",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventDefaultResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/associations/{marketingEventId}/lists/{listId}": {
+            "put": {
+                "tags": [
+                    "List Associations"
+                ],
+                "summary": "Associate list with event",
+                "description": "Associates a list with a marketing event by marketing event id and ILS list id",
+                "operationId": "put-/associations/{marketingEventId}/lists/{listId}_associateByMarketingEventId",
+                "parameters": [
+                    {
+                        "name": "marketingEventId",
+                        "in": "path",
+                        "description": "The internal id of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "listId",
+                        "in": "path",
+                        "description": "The ILS ID of the list",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "List Associations"
+                ],
+                "summary": "Disassociate list from event",
+                "description": "Disassociates a list from a marketing event by marketing event id and ILS list id",
+                "operationId": "delete-/associations/{marketingEventId}/lists/{listId}_disassociateByMarketingEventId",
+                "parameters": [
+                    {
+                        "name": "marketingEventId",
+                        "in": "path",
+                        "description": "The internal id of the marketing event in HubSpot",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "listId",
+                        "in": "path",
+                        "description": "The ILS ID of the list",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/{externalEventId}/{subscriberState}/email-upsert": {
+            "post": {
+                "tags": [
+                    "Subscriber State Changes"
+                ],
+                "summary": "Record subscriber state by email",
+                "description": "Record a subscriber state between multiple HubSpot contacts and a marketing event, using contact email addresses. Note that the contact must already exist in HubSpot; a contact will not be created. The contactProperties field is used only when creating a new contact. These properties will not update existing contacts. ",
+                "operationId": "post-/events/{externalEventId}/{subscriberState}/email-upsert_upsertByContactEmail",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "subscriberState",
+                        "in": "path",
+                        "description": "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputMarketingEventEmailSubscriber"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/associations/{externalAccountId}/{externalEventId}/lists/{listId}": {
+            "put": {
+                "tags": [
+                    "List Associations"
+                ],
+                "summary": "Associate list with event",
+                "description": "Associates a list with a marketing event by external account id, external event id, and ILS list id",
+                "operationId": "put-/associations/{externalAccountId}/{externalEventId}/lists/{listId}_associateByExternalAccountAndEventIds",
+                "parameters": [
+                    {
+                        "name": "externalAccountId",
+                        "in": "path",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "listId",
+                        "in": "path",
+                        "description": "The ILS ID of the list",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "List Associations"
+                ],
+                "summary": "Disassociate a list from event",
+                "description": "Disassociates a list from a marketing event by external account id, external event id, and ILS list id",
+                "operationId": "delete-/associations/{externalAccountId}/{externalEventId}/lists/{listId}_disassociateByExternalAccountAndEventIds",
+                "parameters": [
+                    {
+                        "name": "externalAccountId",
+                        "in": "path",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "listId",
+                        "in": "path",
+                        "description": "The ILS ID of the list",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events/{externalEventId}/complete": {
+            "post": {
+                "tags": [
+                    "Change property"
+                ],
+                "summary": "Mark a marketing event as completed",
+                "description": "Mark a marketing event as completed",
+                "operationId": "post-/events/{externalEventId}/complete_complete",
+                "parameters": [
+                    {
+                        "name": "externalEventId",
+                        "in": "path",
+                        "description": "The id of the marketing event in the external event application",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "externalAccountId",
+                        "in": "query",
+                        "description": "The accountId that is associated with this marketing event in the external event application",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarketingEventCompleteRequestParams"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventDefaultResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/events": {
+            "post": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Create a marketing event",
+                "description": "Creates a new marketing event in HubSpot",
+                "operationId": "post-/events_create",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MarketingEventCreateRequestParams"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketingEventDefaultResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    },
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/participations/contacts/{contactIdentifier}/breakdown": {
+            "get": {
+                "tags": [
+                    "Retrieve Participant State"
+                ],
+                "summary": "Get participation breakdown",
+                "description": "Read Contact's participations by identifier - email or internal id.",
+                "operationId": "get-/participations/contacts/{contactIdentifier}/breakdown_getParticipationsBreakdownByContactId",
+                "parameters": [
+                    {
+                        "name": "contactIdentifier",
+                        "in": "path",
+                        "description": "The identifier of the Contact. It may be email or internal id",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "description": "The participation state value. It may be REGISTERED, CANCELLED, ATTENDED, NO_SHOW",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The limit for response size. The default value is 10, the max number is 100",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The cursor indicating the position of the last retrieved item",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalParticipationBreakdownForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/{appId}/settings": {
+            "get": {
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Retrieve the application settings",
+                "description": "Retrieve the current settings for the application.",
+                "operationId": "get-/{appId}/settings_getAll",
+                "parameters": [
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "description": "The id of the application to retrieve the settings for",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventDetailSettings"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Update the application settings",
+                "description": "Create or update the current settings for the application.",
+                "operationId": "post-/{appId}/settings_update",
+                "parameters": [
+                    {
+                        "name": "appId",
+                        "in": "path",
+                        "description": "The id of the application to update the settings for",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventDetailSettingsUrl"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EventDetailSettings"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "developer_hapikey": []
+                    }
+                ]
+            }
+        },
+        "/events/search": {
+            "get": {
+                "tags": [
+                    "Identifiers"
+                ],
+                "summary": "Find events by external ID",
+                "description": "Retrieves Marketing Events where the externalEventId matches the value provided in the request, limited to events created by the app making the request.\n\nMarketing Events created by other apps will not be included in the results.",
+                "operationId": "get-/events/search_doSearch",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "The id of the marketing event in the external event application (externalEventId)",
+                        "required": true,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseSearchPublicResponseWrapperNoPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "crm.objects.marketing_events.read"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "MarketingEventCompleteRequestParams": {
+                "required": [
+                    "endDateTime",
+                    "startDateTime"
+                ],
+                "type": "object",
+                "properties": {
+                    "startDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The start date and time of the marketing event."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The end date and time of the marketing event."
+                    }
+                },
+                "description": "Parameters required to mark a marketing event as complete, including its start and end times."
+            },
+            "ParticipationProperties": {
+                "required": [
+                    "attendanceState",
+                    "occurredAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "occurredAt": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Unix timestamp (ms) when the participation event occurred."
+                    },
+                    "attendancePercentage": {
+                        "type": "string",
+                        "description": "Percentage of the event the contact attended."
+                    },
+                    "attendanceState": {
+                        "type": "string",
+                        "enum": [
+                            "REGISTERED",
+                            "ATTENDED",
+                            "CANCELLED",
+                            "EMPTY",
+                            "NO_SHOW"
+                        ],
+                        "description": "Contact's attendance status: REGISTERED, ATTENDED, CANCELLED, EMPTY, or NO_SHOW."
+                    },
+                    "attendanceDurationSeconds": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total duration in seconds the contact attended the event."
+                    }
+                },
+                "description": "Properties describing a contact's participation state and engagement in a marketing event."
+            },
+            "SubscriberEmailResponse": {
+                "required": [
+                    "email",
+                    "vid"
+                ],
+                "type": "object",
+                "properties": {
+                    "vid": {
+                        "type": "integer",
+                        "description": "The HubSpot contact ID (VID) of the subscriber."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The email address of the subscriber."
+                    }
+                },
+                "description": "Response object containing a HubSpot contact's ID and email address."
+            },
+            "MarketingEventPublicReadResponse": {
+                "required": [
+                    "attendees",
+                    "cancellations",
+                    "createdAt",
+                    "eventName",
+                    "eventOrganizer",
+                    "externalEventId",
+                    "id",
+                    "noShows",
+                    "registrants",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "registrants": {
+                        "type": "integer",
+                        "description": "The number of HubSpot contacts that registered for this marketing event",
+                        "format": "int32"
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer of the marketing event"
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "A URL in the external event application where the marketing event can be managed"
+                    },
+                    "attendees": {
+                        "type": "integer",
+                        "description": "The number of HubSpot contacts that attended this marketing event",
+                        "format": "int32"
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The type of the marketing event"
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "description": "The end date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "noShows": {
+                        "type": "integer",
+                        "description": "The number of HubSpot contacts that registered for this marketing event, but did not attend. This field only had a value when the event is over",
+                        "format": "int32"
+                    },
+                    "cancellations": {
+                        "type": "integer",
+                        "description": "The number of HubSpot contacts that registered for this marketing event, but later cancelled their registration",
+                        "format": "int32"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "description": "Timestamp when the marketing event record was created.",
+                        "format": "datetime"
+                    },
+                    "startDateTime": {
+                        "type": "string",
+                        "description": "The start date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "description": "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        }
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates if the marketing event has been cancelled"
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The id of the marketing event in the external event application"
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "The description of the marketing event"
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event"
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique HubSpot identifier for the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The HubSpot object ID associated with the marketing event."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "description": "Timestamp when the marketing event record was last updated.",
+                        "format": "datetime"
+                    }
+                },
+                "description": "Full details of a marketing event, including organizer info, scheduling, attendance counts, and custom properties."
+            },
+            "MarketingEventAssociation": {
+                "required": [
+                    "marketingEventId",
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "externalAccountId": {
+                        "type": "string",
+                        "description": "The account ID in the external event application."
+                    },
+                    "marketingEventId": {
+                        "type": "string",
+                        "description": "The unique identifier of the associated marketing event."
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The external identifier of the associated marketing event."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the associated marketing event."
+                    }
+                },
+                "description": "Represents an association between a HubSpot record and a marketing event."
+            },
+            "ErrorDetail": {
+                "required": [
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The status code associated with the error detail"
+                    },
+                    "in": {
+                        "type": "string",
+                        "description": "The name of the field or parameter in which the error was found"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate"
+                    }
+                },
+                "description": "Detailed information about a specific error, including its message, status code, affected field, category, and contextual data."
+            },
+            "MarketingEventEmailSubscriber": {
+                "required": [
+                    "email",
+                    "interactionDateTime"
+                ],
+                "type": "object",
+                "properties": {
+                    "contactProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of HubSpot contact properties to set on the contact."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of additional properties associated with the subscriber."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The email address of the contact in HubSpot to associate with the event"
+                    },
+                    "interactionDateTime": {
+                        "type": "integer",
+                        "description": "Timestamp in milliseconds at which the contact subscribed to the event",
+                        "format": "int64"
+                    }
+                },
+                "description": "Represents an email-identified contact to associate with a marketing event, including their email address, subscription timestamp, and optional properties."
+            },
+            "ForwardPaging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Reference to the next page of results in the paginated response."
+                    }
+                },
+                "description": "Pagination metadata for forward-only traversal, containing a reference to the next page of results."
+            },
+            "PublicList": {
+                "required": [
+                    "listId",
+                    "listVersion",
+                    "name",
+                    "objectTypeId",
+                    "processingStatus",
+                    "processingType"
+                ],
+                "type": "object",
+                "properties": {
+                    "processingType": {
+                        "type": "string",
+                        "description": "The processing method used to evaluate list membership."
+                    },
+                    "objectTypeId": {
+                        "type": "string",
+                        "description": "The type identifier of objects contained in the list."
+                    },
+                    "updatedById": {
+                        "type": "string",
+                        "description": "The ID of the user who last updated the list."
+                    },
+                    "filtersUpdatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the list's filter criteria were last updated."
+                    },
+                    "listId": {
+                        "type": "string",
+                        "description": "The unique identifier of the list."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the list was created."
+                    },
+                    "processingStatus": {
+                        "type": "string",
+                        "description": "The current processing status of the list."
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the list was deleted, if applicable."
+                    },
+                    "listVersion": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The version number of the list."
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "The total number of members in the list."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The display name of the list."
+                    },
+                    "createdById": {
+                        "type": "string",
+                        "description": "The ID of the user who created the list."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp of the most recent update to the list."
+                    }
+                },
+                "description": "Represents a HubSpot list, including its identifier, name, object type, processing configuration, membership size, and audit timestamps."
+            },
+            "MarketingEventExternalUniqueIdentifier": {
+                "required": [
+                    "appId",
+                    "externalAccountId",
+                    "externalEventId"
+                ],
+                "type": "object",
+                "properties": {
+                    "externalAccountId": {
+                        "type": "string",
+                        "description": "The accountId that is associated with this marketing event in the external event application"
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The id of the marketing event in the external event application"
+                    },
+                    "appId": {
+                        "type": "integer",
+                        "description": "The id of the application that created the marketing event in HubSpot",
+                        "format": "int32"
+                    }
+                },
+                "description": "Uniquely identifies a marketing event across the external application, HubSpot app, and account."
+            },
+            "CrmPropertyWrapper": {
+                "required": [
+                    "name",
+                    "value"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The internal name of the CRM property."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The value assigned to the CRM property."
+                    }
+                },
+                "description": "A name-value pair representing a custom CRM property on a marketing event."
+            },
+            "SearchPublicResponseWrapper": {
+                "required": [
+                    "appId",
+                    "externalAccountId",
+                    "externalEventId",
+                    "objectId"
+                ],
+                "type": "object",
+                "properties": {
+                    "externalAccountId": {
+                        "type": "string",
+                        "description": "The account ID from the external event application."
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The event ID from the external event application."
+                    },
+                    "appId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The ID of the app that created the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The HubSpot object ID of the marketing event."
+                    }
+                },
+                "description": "Represents a search result identifying a marketing event by its external and HubSpot object identifiers."
+            },
+            "SubscriberVidResponse": {
+                "required": [
+                    "vid"
+                ],
+                "type": "object",
+                "properties": {
+                    "vid": {
+                        "type": "integer"
+                    }
+                },
+                "description": "Contains the HubSpot contact visitor ID returned after a subscriber operation."
+            },
+            "MarketingEventPublicUpdateRequestV2": {
+                "required": [
+                    "customProperties"
+                ],
+                "type": "object",
+                "properties": {
+                    "startDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The scheduled start date and time of the marketing event."
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        },
+                        "description": "A list of custom CRM properties to associate with the marketing event."
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been cancelled."
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer responsible for the event."
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "The URL of the marketing event's landing or registration page."
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "A text description providing details about the marketing event."
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event."
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The type of event (e.g., WEBINAR, CONFERENCE, WORKSHOP)."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The end date and time of the marketing event."
+                    }
+                },
+                "description": "Request payload for partially updating an existing marketing event's details and custom properties."
+            },
+            "MarketingEventIdentifiersResponse": {
+                "required": [
+                    "externalEventId",
+                    "marketingEventName",
+                    "objectId"
+                ],
+                "type": "object",
+                "properties": {
+                    "externalAccountId": {
+                        "type": "string",
+                        "description": "The external account ID associated with the marketing event."
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The unique identifier of the event in the external application."
+                    },
+                    "appInfo": {
+                        "$ref": "#/components/schemas/AppInfo",
+                        "description": "Information about the application associated with the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The HubSpot object ID of the marketing event."
+                    },
+                    "marketingEventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event."
+                    }
+                },
+                "description": "Response object containing identifiers that uniquely reference a marketing event, including its external ID, HubSpot object ID, and associated app info."
+            },
+            "BatchInputMarketingEventExternalUniqueIdentifier": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventExternalUniqueIdentifier"
+                        },
+                        "description": "A list of external unique identifiers for the marketing events."
+                    }
+                },
+                "description": "Batch input object containing a list of external unique identifiers for marketing events."
+            },
+            "MarketingEventUpdateRequestParams": {
+                "type": "object",
+                "properties": {
+                    "startDateTime": {
+                        "type": "string",
+                        "description": "The start date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "description": "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        }
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates if the marketing event has been cancelled. Defaults to `false`"
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer of the marketing event"
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "A URL in the external event application where the marketing event can be managed"
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "The description of the marketing event"
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event"
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "Describes what type of event this is.  For example: `WEBINAR`, `CONFERENCE`, `WORKSHOP`"
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "description": "The end date and time of the marketing event",
+                        "format": "datetime"
+                    }
+                },
+                "description": "Request parameters for updating an existing marketing event, including scheduling, organizer details, custom properties, and status flags."
+            },
+            "AppInfo": {
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the application."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the application."
+                    }
+                },
+                "description": "Object containing identifying information about the application associated with a marketing event."
+            },
+            "CollectionResponseWithTotalPublicListNoPaging": {
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of results in the collection."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicList"
+                        },
+                        "description": "The array of public list objects returned in the response."
+                    }
+                },
+                "description": "A collection response containing a total count and an array of public lists, returned without paging metadata."
+            },
+            "ContactAssociation": {
+                "required": [
+                    "contactId",
+                    "email"
+                ],
+                "type": "object",
+                "properties": {
+                    "firstname": {
+                        "type": "string",
+                        "description": "The contact's first name."
+                    },
+                    "contactId": {
+                        "type": "string",
+                        "description": "The unique identifier of the associated contact."
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The email address of the associated contact."
+                    },
+                    "lastname": {
+                        "type": "string",
+                        "description": "The contact's last name."
+                    }
+                },
+                "description": "Represents a contact association for a marketing event, linking a contact by ID and email along with optional name details."
+            },
+            "ParticipationBreakdown": {
+                "required": [
+                    "associations",
+                    "createdAt",
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "$ref": "#/components/schemas/ParticipationAssociations",
+                        "description": "The associations linked to this participation record."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime when the participation record was created."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the participation record."
+                    },
+                    "properties": {
+                        "$ref": "#/components/schemas/ParticipationProperties",
+                        "description": "The properties associated with this participation record."
+                    }
+                },
+                "description": "Detailed breakdown of a contact's participation in a marketing event, including associations, timestamps, and properties."
+            },
+            "MarketingEventPublicDefaultResponse": {
+                "required": [
+                    "createdAt",
+                    "eventName",
+                    "eventOrganizer",
+                    "id",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer of the marketing event"
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "A URL in the external event application where the marketing event can be managed"
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The type of the marketing event"
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "description": "The end date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "description": "The datetime when the marketing event record was created.",
+                        "format": "datetime"
+                    },
+                    "startDateTime": {
+                        "type": "string",
+                        "description": "The start date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "description": "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        }
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates if the marketing event has been cancelled"
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "The description of the marketing event"
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event"
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The HubSpot object ID associated with the marketing event."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "description": "The datetime when the marketing event record was last updated.",
+                        "format": "datetime"
+                    }
+                },
+                "description": "Default response object representing a marketing event, including its details, status, and custom properties."
+            },
+            "BatchResponseSubscriberVidResponse": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime when the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource links for the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SubscriberVidResponse"
+                        },
+                        "description": "List of subscriber VID responses returned in the batch."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered during batch processing."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch response containing subscriber VID results, processing status, error counts, and timestamps."
+            },
+            "MarketingEventDefaultResponse": {
+                "required": [
+                    "eventName",
+                    "eventOrganizer"
+                ],
+                "type": "object",
+                "properties": {
+                    "startDateTime": {
+                        "type": "string",
+                        "description": "The start date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "description": "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        }
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates if the marketing event has been cancelled"
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer of the marketing event"
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "The URL in the external event application where the marketing event can be managed"
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "The description of the marketing event"
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event"
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The type of the marketing event"
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "description": "The end date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The HubSpot object ID of the marketing event."
+                    }
+                },
+                "description": "Default response schema representing a marketing event, including its name, organizer, dates, type, description, URL, and optional custom properties."
+            },
+            "ParticipationAssociations": {
+                "required": [
+                    "contact",
+                    "marketingEvent"
+                ],
+                "type": "object",
+                "properties": {
+                    "marketingEvent": {
+                        "$ref": "#/components/schemas/MarketingEventAssociation",
+                        "description": "Association reference to the related marketing event."
+                    },
+                    "contact": {
+                        "$ref": "#/components/schemas/ContactAssociation",
+                        "description": "Association reference to the related contact."
+                    }
+                },
+                "description": "Defines the associations between a contact and a marketing event for participation tracking."
+            },
+            "BatchInputMarketingEventSubscriber": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "description": "List of HubSpot contacts to subscribe to the marketing event",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventSubscriber"
+                        }
+                    }
+                },
+                "description": "Batch input schema containing a list of HubSpot contacts to subscribe to a marketing event."
+            },
+            "StandardError": {
+                "required": [
+                    "category",
+                    "context",
+                    "errors",
+                    "links",
+                    "message",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "Optional sub-category providing additional error classification."
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Key-value map of contextual details related to the error."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the error."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the error instance."
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "High-level category classifying the type of error."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable message describing the error."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "List of detailed error entries associated with this error.",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "HTTP status or error state associated with this error."
+                    }
+                },
+                "description": "Standard error response schema containing status, category, message, context, and error details."
+            },
+            "MarketingEventCreateRequestParams": {
+                "required": [
+                    "eventName",
+                    "eventOrganizer",
+                    "externalAccountId",
+                    "externalEventId"
+                ],
+                "type": "object",
+                "properties": {
+                    "startDateTime": {
+                        "type": "string",
+                        "description": "The start date and time of the marketing event",
+                        "format": "datetime"
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "description": "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        }
+                    },
+                    "externalAccountId": {
+                        "type": "string",
+                        "description": "The accountId that is associated with this marketing event in the external event application"
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates if the marketing event has been cancelled.  Defaults to `false`"
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer of the marketing event"
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "A URL in the external event application where the marketing event can be managed"
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The id of the marketing event in the external event application"
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "The description of the marketing event"
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event"
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "Describes what type of event this is.  For example: `WEBINAR`, `CONFERENCE`, `WORKSHOP`"
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "description": "The end date and time of the marketing event",
+                        "format": "datetime"
+                    }
+                },
+                "description": "Request parameters for creating a new marketing event, including required identifiers, organizer details, scheduling, and optional custom properties."
+            },
+            "BatchInputMarketingEventPublicUpdateRequestFullV2": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventPublicUpdateRequestFullV2"
+                        },
+                        "description": "List of marketing event update requests to process in the batch."
+                    }
+                },
+                "description": "Batch request payload containing a list of marketing events to update in bulk."
+            },
+            "CollectionResponseWithTotalMarketingEventIdentifiersResponseNoPaging": {
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of marketing event identifier results returned."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventIdentifiersResponse"
+                        },
+                        "description": "List of marketing event identifier response objects."
+                    }
+                },
+                "description": "A collection response containing marketing event identifiers along with the total count of results."
+            },
+            "EventDetailSettings": {
+                "required": [
+                    "appId",
+                    "eventDetailsUrl"
+                ],
+                "type": "object",
+                "properties": {
+                    "appId": {
+                        "type": "integer",
+                        "description": "The id of the application the settings are for",
+                        "format": "int32"
+                    },
+                    "eventDetailsUrl": {
+                        "type": "string",
+                        "description": "The url that will be used to fetch marketing event details by id"
+                    }
+                },
+                "description": "Configuration settings for an application's marketing event detail URL, keyed by app ID."
+            },
+            "MarketingEventSubscriber": {
+                "required": [
+                    "interactionDateTime",
+                    "vid"
+                ],
+                "type": "object",
+                "properties": {
+                    "vid": {
+                        "type": "integer",
+                        "description": "The HubSpot contact ID (vid) of the event subscriber."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Additional key-value properties associated with the subscriber."
+                    },
+                    "interactionDateTime": {
+                        "type": "integer",
+                        "description": "Timestamp in milliseconds at which the contact subscribed to the event",
+                        "format": "int64"
+                    }
+                },
+                "description": "Represents a contact subscriber for a marketing event, including their ID, interaction timestamp, and additional properties."
+            },
+            "EventDetailSettingsUrl": {
+                "required": [
+                    "eventDetailsUrl"
+                ],
+                "type": "object",
+                "properties": {
+                    "eventDetailsUrl": {
+                        "type": "string",
+                        "description": "The url that will be used to fetch marketing event details by id. Must contain a `%s` character sequence that will be substituted with the event id. For example: `https://my.event.app/events/%s`"
+                    }
+                },
+                "description": "Defines the URL template used to fetch marketing event details by ID, requiring a `%s` placeholder for the event ID."
+            },
+            "BatchInputMarketingEventEmailSubscriber": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "description": "List of marketing event details to create or update",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventEmailSubscriber"
+                        }
+                    }
+                },
+                "description": "Batch request payload containing a list of marketing event email subscriber records to create or update."
+            },
+            "CollectionResponseMarketingEventPublicReadResponseV2ForwardPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging information for retrieving the next page of results."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventPublicReadResponseV2"
+                        },
+                        "description": "List of marketing event public read response objects (V2)."
+                    }
+                },
+                "description": "A paginated collection response containing a list of marketing event read responses with optional forward paging details."
+            },
+            "MarketingEventPublicDefaultResponseV2": {
+                "required": [
+                    "createdAt",
+                    "customProperties",
+                    "eventName",
+                    "objectId",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the organizer of the marketing event."
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "URL to the event in the external event application."
+                    },
+                    "appInfo": {
+                        "$ref": "#/components/schemas/AppInfo",
+                        "description": "Information about the application associated with this marketing event."
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The type or category of the marketing event."
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event ends."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event was created."
+                    },
+                    "startDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event starts."
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        },
+                        "description": "A list of custom CRM properties associated with the marketing event."
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been cancelled."
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "A text description providing details about the marketing event."
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name or title of the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The unique identifier of the marketing event object."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event was last updated."
+                    }
+                },
+                "description": "Default response object for a marketing event (V2), including event details, scheduling, status flags, and custom properties."
+            },
+            "MarketingEventPublicUpdateRequestFullV2": {
+                "required": [
+                    "customProperties",
+                    "objectId"
+                ],
+                "type": "object",
+                "properties": {
+                    "startDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event starts."
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        },
+                        "description": "A list of custom CRM properties to associate with the marketing event."
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Set to true to mark the marketing event as cancelled."
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name or identifier of the event organizer."
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "The URL linking to the marketing event's page or registration."
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "A text description providing details about the marketing event."
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name or title of the marketing event."
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The type or category of the marketing event."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The scheduled end date and time of the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The unique identifier of the marketing event object."
+                    }
+                },
+                "description": "Request body schema for performing a full update of an existing marketing event, including all updatable fields and custom properties."
+            },
+            "MarketingEventPublicReadResponseV2": {
+                "required": [
+                    "createdAt",
+                    "customProperties",
+                    "eventName",
+                    "objectId",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "registrants": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of contacts registered for the event."
+                    },
+                    "eventOrganizer": {
+                        "type": "string",
+                        "description": "The name of the person or organization hosting the event."
+                    },
+                    "eventUrl": {
+                        "type": "string",
+                        "description": "The URL where the marketing event can be accessed or viewed."
+                    },
+                    "attendees": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of contacts who attended the event."
+                    },
+                    "appInfo": {
+                        "$ref": "#/components/schemas/AppInfo",
+                        "description": "Information about the app associated with the marketing event."
+                    },
+                    "eventType": {
+                        "type": "string",
+                        "description": "The category or format type of the marketing event."
+                    },
+                    "eventCompleted": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been completed."
+                    },
+                    "endDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event ends."
+                    },
+                    "noShows": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The number of registered contacts who did not attend the event."
+                    },
+                    "cancellations": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of registrations cancelled for the event."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event record was created."
+                    },
+                    "startDateTime": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The date and time when the marketing event begins."
+                    },
+                    "customProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/CrmPropertyWrapper"
+                        },
+                        "description": "A list of custom CRM properties associated with the marketing event."
+                    },
+                    "eventCancelled": {
+                        "type": "boolean",
+                        "description": "Indicates whether the marketing event has been cancelled."
+                    },
+                    "externalEventId": {
+                        "type": "string",
+                        "description": "The unique identifier of the event in the external source system."
+                    },
+                    "eventStatus": {
+                        "type": "string",
+                        "description": "The current status of the marketing event."
+                    },
+                    "eventDescription": {
+                        "type": "string",
+                        "description": "A text description providing details about the marketing event."
+                    },
+                    "eventName": {
+                        "type": "string",
+                        "description": "The name of the marketing event."
+                    },
+                    "objectId": {
+                        "type": "string",
+                        "description": "The unique identifier of the marketing event object."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime the marketing event was last updated."
+                    }
+                },
+                "description": "Represents the full read response for a marketing event, including metadata, scheduling, attendance statistics, and custom properties."
+            },
+            "BatchInputMarketingEventCreateRequestParams": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "description": "An array of marketing event creation request parameter objects.",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventCreateRequestParams"
+                        }
+                    }
+                },
+                "description": "A batch input object containing an array of marketing event creation request parameters."
+            },
+            "BatchResponseMarketingEventPublicDefaultResponseV2WithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "The datetime the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of relevant link names to associated URIs."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventPublicDefaultResponseV2"
+                        },
+                        "description": "An array of successfully processed marketing event response objects."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "An array of standard error objects for any failed items in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "The current status of the batch operation."
+                    }
+                },
+                "description": "A batch response object containing results, status, timing metadata, and any errors encountered during processing of marketing events."
+            },
+            "Error": {
+                "required": [
+                    "category",
+                    "correlationId",
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ],
+                            "invalidPropertyName": [
+                                "propertyValue"
+                            ]
+                        }
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "A unique identifier for the request. Include this value with any error reports or support tickets",
+                        "format": "uuid",
+                        "example": "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+                        "example": {
+                            "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate",
+                        "example": "Invalid input (details will vary based on the error)"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "The error category",
+                        "example": "VALIDATION_ERROR"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "further information about the error",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    }
+                },
+                "example": {
+                    "message": "Invalid input (details will vary based on the error)",
+                    "correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+                    "category": "VALIDATION_ERROR",
+                    "links": {
+                        "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                    }
+                },
+                "description": "A standard error object containing a message, category, correlation ID, and optional context details for diagnosing API errors."
+            },
+            "BatchInputMarketingEventPublicObjectIdDeleteRequest": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventPublicObjectIdDeleteRequest"
+                        },
+                        "description": "An array of marketing event object ID delete request objects."
+                    }
+                },
+                "description": "A batch input object containing an array of marketing event object ID delete requests."
+            },
+            "CollectionResponseSearchPublicResponseWrapperNoPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SearchPublicResponseWrapper"
+                        },
+                        "description": "An array of search result wrapper objects returned by the query."
+                    }
+                },
+                "description": "A collection response containing an array of search result wrapper objects with no paging information."
+            },
+            "AttendanceCounters": {
+                "required": [
+                    "attended",
+                    "cancelled",
+                    "noShows",
+                    "registered"
+                ],
+                "type": "object",
+                "properties": {
+                    "attended": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of contacts who attended the event."
+                    },
+                    "registered": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of contacts registered for the event."
+                    },
+                    "cancelled": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of contacts who cancelled their registration."
+                    },
+                    "noShows": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Number of registered contacts who did not attend."
+                    }
+                },
+                "description": "An object containing attendance count totals for a marketing event, including registered, attended, cancelled, and no-show figures."
+            },
+            "BatchResponseSubscriberEmailResponse": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant navigational links related to the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SubscriberEmailResponse"
+                        },
+                        "description": "List of subscriber email responses returned by the batch operation."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered during the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch response containing subscriber email operation results, status, timing metadata, and any errors encountered."
+            },
+            "MarketingEventPublicObjectIdDeleteRequest": {
+                "required": [
+                    "objectId"
+                ],
+                "type": "object",
+                "properties": {
+                    "objectId": {
+                        "type": "string",
+                        "description": "The unique identifier of the marketing event to delete."
+                    }
+                },
+                "description": "Request body for deleting a marketing event identified by its object ID."
+            },
+            "CollectionResponseWithTotalParticipationBreakdownForwardPaging": {
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of participation breakdown records available."
+                    },
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging metadata for retrieving the next result page."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParticipationBreakdown"
+                        },
+                        "description": "List of participation breakdown records for the current page."
+                    }
+                },
+                "description": "Paginated collection of participation breakdown records with a total count."
+            },
+            "BatchResponseMarketingEventPublicDefaultResponseV2": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch request completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch request was received."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch request began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant navigation links for the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventPublicDefaultResponseV2"
+                        },
+                        "description": "List of marketing event results returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch request."
+                    }
+                },
+                "description": "Batch response containing marketing event results, processing status, and timing metadata."
+            },
+            "NextPage": {
+                "required": [
+                    "after"
+                ],
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "description": "URL link to the next page of results."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Cursor token identifying the start of the next results page."
+                    }
+                },
+                "description": "Pagination cursor object used to retrieve the next page of results."
+            },
+            "BatchResponseMarketingEventPublicDefaultResponse": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "description": "Timestamp when the batch request completed.",
+                        "format": "datetime"
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "description": "Total number of errors encountered in the batch request.",
+                        "format": "int32"
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "description": "Timestamp when the batch request was received.",
+                        "format": "datetime"
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "description": "Timestamp when the batch request began processing.",
+                        "format": "datetime"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant navigation links for the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "description": "List of marketing event results returned by the batch operation.",
+                        "items": {
+                            "$ref": "#/components/schemas/MarketingEventPublicDefaultResponse"
+                        }
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "List of errors encountered during batch processing.",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Current processing status of the batch request.",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ]
+                    }
+                },
+                "description": "Batch response containing marketing event results, status, and error details."
+            }
+        },
+        "responses": {
+            "Error": {
+                "description": "An error occurred",
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "oauth2_legacy": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.marketing_events.read": "Read marketing events",
+                            "crm.objects.marketing_events.write": "Write marketing events"
+                        }
+                    }
+                }
+            },
+            "developer_hapikey": {
+                "type": "apiKey",
+                "name": "hapikey",
+                "in": "query"
+            },
+            "private_apps_legacy": {
+                "type": "apiKey",
+                "name": "private-app-legacy",
+                "in": "header",
+                "x-ballerina-name": "privateAppLegacy"
+            }
+        }
+    },
+    "x-hubspot-available-client-libraries": [
+        "PHP",
+        "Node",
+        "Ruby",
+        "Python"
+    ],
+    "x-hubspot-product-tier-requirements": {
+        "marketing": "FREE",
+        "cms": "STARTER"
+    },
+    "x-hubspot-documentation-banner": "PUBLIC_BETA"
+}

--- a/docs/spec/flattened_openapi.json
+++ b/docs/spec/flattened_openapi.json
@@ -1,0 +1,3406 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Marketing Events",
+    "version" : "v3",
+    "x-hubspot-product-tier-requirements" : {
+      "marketing" : "FREE",
+      "cms" : "STARTER"
+    },
+    "x-hubspot-documentation-banner" : "PUBLIC_BETA",
+    "x-hubspot-api-use-case" : "You have an external system that handles registration for your webinars and you want to ensure that attendee data and behavior is synced with your HubSpot CRM.",
+    "x-hubspot-related-documentation" : [ {
+      "name" : "Marketing Events Guide",
+      "url" : "https://developers.hubspot.com/beta-docs/guides/api/marketing/marketing-events"
+    } ],
+    "x-hubspot-introduction" : "A marketing event is a CRM object, similar to contacts and companies, that enables you to track marketing events, such as a webinar, along with the contacts who registered and attended the event. Below, learn more about working with the marketing event API to integrate marketing events into an app."
+  },
+  "servers" : [ {
+    "url" : "https://api.hubapi.com/marketing/v3/marketing-events"
+  } ],
+  "tags" : [ {
+    "name" : "Add event attendees"
+  }, {
+    "name" : "Retrieve Participant State"
+  }, {
+    "name" : "Subscriber State Changes"
+  }, {
+    "name" : "Basic"
+  }, {
+    "name" : "Batch"
+  }, {
+    "name" : "List Associations"
+  }, {
+    "name" : "Identifiers"
+  }, {
+    "name" : "Change property"
+  }, {
+    "name" : "Settings"
+  } ],
+  "paths" : {
+    "/attendance/{externalEventId}/{subscriberState}/create" : {
+      "post" : {
+        "tags" : [ "Add event attendees" ],
+        "summary" : "Record Participants by ContactId with Marketing Event External Ids",
+        "description" : "Records the participation of multiple HubSpot contacts in a Marketing Event using their HubSpot contact IDs.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+        "operationId" : "post-/attendance/{externalEventId}/{subscriberState}/create_recordByContactIds",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subscriberState",
+          "in" : "path",
+          "description" : "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventSubscriber"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSubscriberVidResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/participations/{marketingEventId}/breakdown" : {
+      "get" : {
+        "tags" : [ "Retrieve Participant State" ],
+        "summary" : "Read participations breakdown by Marketing Event internal identifier",
+        "description" : "Read Marketing event's participations breakdown with optional filters by internal identifier marketingEventId.",
+        "operationId" : "get-/participations/{marketingEventId}/breakdown_getParticipationsBreakdownByMarketingEventId",
+        "parameters" : [ {
+          "name" : "marketingEventId",
+          "in" : "path",
+          "description" : "The internal id of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }, {
+          "name" : "contactIdentifier",
+          "in" : "query",
+          "description" : "The identifier of the Contact. It may be email or internal id",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "state",
+          "in" : "query",
+          "description" : "The participation state value. It may be REGISTERED, CANCELLED, ATTENDED, NO_SHOW",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The limit for response size. The default value is 10, the max number is 100",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The cursor indicating the position of the last retrieved item",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalParticipationBreakdownForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/events/{externalEventId}/{subscriberState}/upsert" : {
+      "post" : {
+        "tags" : [ "Subscriber State Changes" ],
+        "summary" : "Record a subscriber state by contact ID",
+        "description" : "Record a subscriber state between multiple HubSpot contacts and a marketing event, using HubSpot contact IDs. Note that the contact must already exist in HubSpot; a contact will not be created.",
+        "operationId" : "post-/events/{externalEventId}/{subscriberState}/upsert_upsertByContactId",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subscriberState",
+          "in" : "path",
+          "description" : "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventSubscriber"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/events/{externalEventId}" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Get Marketing Event by External IDs",
+        "description" : "Returns the details of a Marketing Event with the specified externalAccountId, externalEventId, if it exists.\n\nOnly Marketing Events created by the same app making the request can be retrieved.",
+        "operationId" : "get-/events/{externalEventId}_getDetails",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventPublicReadResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      },
+      "put" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Create or update a marketing event",
+        "description" : "Upserts a marketing event If there is an existing marketing event with the specified ID, it will be updated; otherwise a new event will be created.",
+        "operationId" : "put-/events/{externalEventId}_upsert",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MarketingEventCreateRequestParams"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventPublicDefaultResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Delete Marketing Event by External Ids",
+        "description" : "Deletes the existing Marketing Event with the specified externalAccountId, externalEventId, if it exists.\n\nOnly Marketing Events created by the same app can be deleted.",
+        "operationId" : "delete-/events/{externalEventId}_archive",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Update Marketing Event by External IDs",
+        "description" : "Updates the details of an existing Marketing Event identified by its externalAccountId, externalEventId if it exists.\n\nOnly Marketing Events created by the same app can be updated.",
+        "operationId" : "patch-/events/{externalEventId}_update",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MarketingEventUpdateRequestParams"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventPublicDefaultResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/events/upsert" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create or Update Multiple Marketing Events",
+        "description" : "Upserts multiple Marketing Events. If a Marketing Event with the specified ID already exists, it will be updated; otherwise, a new event will be created.\n\nOnly Marketing Events originally created by the same app can be updated.",
+        "operationId" : "post-/events/upsert_batchUpsert",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventCreateRequestParams"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseMarketingEventPublicDefaultResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/attendance/{externalEventId}/{subscriberState}/email-create" : {
+      "post" : {
+        "tags" : [ "Add event attendees" ],
+        "summary" : "Record Participants by Email with Marketing Event External Ids",
+        "description" : "Records the participation of multiple HubSpot contacts in a Marketing Event using their email addresses.\n\nIf a contact does not exist, it will be automatically created. The contactProperties field is used exclusively for creating new contacts and will not update properties of existing contacts.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+        "operationId" : "post-/attendance/{externalEventId}/{subscriberState}/email-create_recordByContactEmails",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subscriberState",
+          "in" : "path",
+          "description" : "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventEmailSubscriber"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSubscriberEmailResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/participations/{externalAccountId}/{externalEventId}/breakdown" : {
+      "get" : {
+        "tags" : [ "Retrieve Participant State" ],
+        "summary" : "Read participations breakdown by Marketing Event external identifier",
+        "description" : "Read Marketing event's participations breakdown with optional filters by externalAccountId and externalEventId pair.",
+        "operationId" : "get-/participations/{externalAccountId}/{externalEventId}/breakdown_getParticipationsBreakdownByExternalEventId",
+        "parameters" : [ {
+          "name" : "externalAccountId",
+          "in" : "path",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "contactIdentifier",
+          "in" : "query",
+          "description" : "The identifier of the Contact. It may be email or internal id",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "state",
+          "in" : "query",
+          "description" : "The participation state value. It may be REGISTERED, CANCELLED, ATTENDED, NO_SHOW",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The limit for response size. The default value is 10, the max number is 100",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The cursor indicating the position of the last retrieved item",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalParticipationBreakdownForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/{objectId}" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Get Marketing Event by objectId",
+        "description" : "Returns the details of a Marketing Event with the specified objectId, if it exists.",
+        "operationId" : "get-/{objectId}",
+        "parameters" : [ {
+          "name" : "objectId",
+          "in" : "path",
+          "description" : "The internal ID of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventPublicReadResponseV2"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Delete Marketing Event by objectId",
+        "description" : "Deletes the existing Marketing Event with the specified objectId, if it exists.",
+        "operationId" : "delete-/{objectId}",
+        "parameters" : [ {
+          "name" : "objectId",
+          "in" : "path",
+          "description" : "The internal ID of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Update Marketing Event by objectId",
+        "description" : "Updates the details of an existing Marketing Event identified by its objectId, if it exists.",
+        "operationId" : "patch-/{objectId}",
+        "parameters" : [ {
+          "name" : "objectId",
+          "in" : "path",
+          "description" : "The internal ID of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MarketingEventPublicUpdateRequestV2"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventPublicDefaultResponseV2"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/associations/{externalAccountId}/{externalEventId}/lists" : {
+      "get" : {
+        "tags" : [ "List Associations" ],
+        "summary" : "Get lists associated with a marketing event",
+        "description" : "Gets lists associated with a marketing event by external account id and external event id",
+        "operationId" : "get-/associations/{externalAccountId}/{externalEventId}/lists_getAllByExternalAccountAndEventIds",
+        "parameters" : [ {
+          "name" : "externalAccountId",
+          "in" : "path",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalPublicListNoPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/associations/{marketingEventId}/lists" : {
+      "get" : {
+        "tags" : [ "List Associations" ],
+        "summary" : "Get lists associated with a marketing event",
+        "description" : "Gets lists associated with a marketing event by marketing event id",
+        "operationId" : "get-/associations/{marketingEventId}/lists_getAllByMarketingEventId",
+        "parameters" : [ {
+          "name" : "marketingEventId",
+          "in" : "path",
+          "description" : "The internal id of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalPublicListNoPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/{objectId}/attendance/{subscriberState}/email-create" : {
+      "post" : {
+        "tags" : [ "Add event attendees" ],
+        "summary" : "Record Participants by Email with Marketing Event Object Id",
+        "description" : "Records the participation of multiple HubSpot contacts in a Marketing Event using their email addresses.\n\nIf a contact does not exist, it will be automatically created. The contactProperties field is used exclusively for creating new contacts and will not update properties of existing contacts.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+        "operationId" : "post-/{objectId}/attendance/{subscriberState}/email-create",
+        "parameters" : [ {
+          "name" : "objectId",
+          "in" : "path",
+          "description" : "The internal ID of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subscriberState",
+          "in" : "path",
+          "description" : "The attendance state value. It may be 'register', 'attend' or 'cancel'",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventEmailSubscriber"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSubscriberEmailResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Get all marketing event",
+        "description" : "Returns all Marketing Events available on the portal, along with their properties, regardless of whether they were created manually or through the application.\n\nThe marketing events returned by this endpoint are sorted by objectId.",
+        "operationId" : "get-/",
+        "parameters" : [ {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The cursor indicating the position of the last retrieved item",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The limit for response size. The default value is 10, the max number is 100",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseMarketingEventPublicReadResponseV2ForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/batch/update" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Update Multiple Marketing Events by ObjectId",
+        "description" : "Updates multiple Marketing Events on the portal based on their objectId, if they exist.",
+        "operationId" : "post-/batch/update",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventPublicUpdateRequestFullV2"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseMarketingEventPublicDefaultResponseV2"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseMarketingEventPublicDefaultResponseV2WithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/{objectId}/attendance/{subscriberState}/create" : {
+      "post" : {
+        "tags" : [ "Add event attendees" ],
+        "summary" : "Record Participants by ContactId with Marketing Event Object Id",
+        "description" : "Records the participation of multiple HubSpot contacts in a Marketing Event using their HubSpot contact IDs.\n\nAdditional Functionality:\n- Adds a timeline event to the contacts.\n\nAllowed Properties:\nFor the state \"attend\":\n- joinedAt\n- leftAt",
+        "operationId" : "post-/{objectId}/attendance/{subscriberState}/create",
+        "parameters" : [ {
+          "name" : "objectId",
+          "in" : "path",
+          "description" : "The internal id of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subscriberState",
+          "in" : "path",
+          "description" : "The attendance state value. It may be 'register', 'attend' or 'cancel'",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventSubscriber"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSubscriberVidResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/batch/archive" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Delete Multiple Marketing Events by ObjectId",
+        "description" : "Deletes multiple Marketing Events from the portal based on their objectId, if they exist.\n\nResponses:\n204: Returned if all specified Marketing Events were successfully deleted.\n207: Returned if some objectIds did not correspond to any existing Marketing Events.",
+        "operationId" : "post-/batch/archive",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventPublicObjectIdDeleteRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/participations/{externalAccountId}/{externalEventId}" : {
+      "get" : {
+        "tags" : [ "Retrieve Participant State" ],
+        "summary" : "Read participations counters by Marketing Event external identifier",
+        "description" : "Read Marketing event's participations counters by externalAccountId and externalEventId pair.",
+        "operationId" : "get-/participations/{externalAccountId}/{externalEventId}_getParticipationsCountersByEventExternalId",
+        "parameters" : [ {
+          "name" : "externalAccountId",
+          "in" : "path",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AttendanceCounters"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/{externalEventId}/identifiers" : {
+      "get" : {
+        "tags" : [ "Identifiers" ],
+        "summary" : "Find Marketing Events by externalEventId",
+        "description" : "This endpoint searches the portal for all Marketing Events whose externalEventId matches the value provided in the request.\n\nIt retrieves the objectId and additional event details for each matching Marketing Event.\n\nSince multiple Marketing Events can have the same externalEventId, the endpoint returns all matching results.\n\nNote: Marketing Events become searchable by externalEventId a few minutes after creation.",
+        "operationId" : "get-/{externalEventId}/identifiers",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalMarketingEventIdentifiersResponseNoPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/participations/{marketingEventId}" : {
+      "get" : {
+        "tags" : [ "Retrieve Participant State" ],
+        "summary" : "Read participations counters by Marketing Event internal identifier",
+        "description" : "Read Marketing event's participations counters by internal identifier marketingEventId.",
+        "operationId" : "get-/participations/{marketingEventId}_getParticipationsCountersByMarketingEventId",
+        "parameters" : [ {
+          "name" : "marketingEventId",
+          "in" : "path",
+          "description" : "The internal id of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AttendanceCounters"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/events/delete" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Delete Multiple Marketing Events by External Ids",
+        "description" : "Deletes multiple Marketing Events based on externalAccountId, externalEventId, and appId.\n\nOnly Marketing Events created by the same apps will be deleted; events from other apps cannot be removed by this endpoint. ",
+        "operationId" : "post-/events/delete_batchArchive",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventExternalUniqueIdentifier"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/events/{externalEventId}/cancel" : {
+      "post" : {
+        "tags" : [ "Change property" ],
+        "summary" : "Mark a marketing event as cancelled",
+        "description" : "Mark a marketing event as cancelled.",
+        "operationId" : "post-/events/{externalEventId}/cancel_cancel",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventDefaultResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/associations/{marketingEventId}/lists/{listId}" : {
+      "put" : {
+        "tags" : [ "List Associations" ],
+        "summary" : "Associate a list with a marketing event",
+        "description" : "Associates a list with a marketing event by marketing event id and ILS list id",
+        "operationId" : "put-/associations/{marketingEventId}/lists/{listId}_associateByMarketingEventId",
+        "parameters" : [ {
+          "name" : "marketingEventId",
+          "in" : "path",
+          "description" : "The internal id of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "listId",
+          "in" : "path",
+          "description" : "The ILS ID of the list",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "List Associations" ],
+        "summary" : "Disassociate a list from a marketing event",
+        "description" : "Disassociates a list from a marketing event by marketing event id and ILS list id",
+        "operationId" : "delete-/associations/{marketingEventId}/lists/{listId}_disassociateByMarketingEventId",
+        "parameters" : [ {
+          "name" : "marketingEventId",
+          "in" : "path",
+          "description" : "The internal id of the marketing event in HubSpot",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "listId",
+          "in" : "path",
+          "description" : "The ILS ID of the list",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/events/{externalEventId}/{subscriberState}/email-upsert" : {
+      "post" : {
+        "tags" : [ "Subscriber State Changes" ],
+        "summary" : "Record a subscriber state by contact email",
+        "description" : "Record a subscriber state between multiple HubSpot contacts and a marketing event, using contact email addresses. Note that the contact must already exist in HubSpot; a contact will not be created. The contactProperties field is used only when creating a new contact. These properties will not update existing contacts. ",
+        "operationId" : "post-/events/{externalEventId}/{subscriberState}/email-upsert_upsertByContactEmail",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subscriberState",
+          "in" : "path",
+          "description" : "The new subscriber state for the HubSpot contacts and the specified marketing event. For example: 'register', 'attend' or 'cancel'",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputMarketingEventEmailSubscriber"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/associations/{externalAccountId}/{externalEventId}/lists/{listId}" : {
+      "put" : {
+        "tags" : [ "List Associations" ],
+        "summary" : "Associate a list with a marketing event",
+        "description" : "Associates a list with a marketing event by external account id, external event id, and ILS list id",
+        "operationId" : "put-/associations/{externalAccountId}/{externalEventId}/lists/{listId}_associateByExternalAccountAndEventIds",
+        "parameters" : [ {
+          "name" : "externalAccountId",
+          "in" : "path",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "listId",
+          "in" : "path",
+          "description" : "The ILS ID of the list",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "List Associations" ],
+        "summary" : "Disassociate a list from a marketing event",
+        "description" : "Disassociates a list from a marketing event by external account id, external event id, and ILS list id",
+        "operationId" : "delete-/associations/{externalAccountId}/{externalEventId}/lists/{listId}_disassociateByExternalAccountAndEventIds",
+        "parameters" : [ {
+          "name" : "externalAccountId",
+          "in" : "path",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "listId",
+          "in" : "path",
+          "description" : "The ILS ID of the list",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/events/{externalEventId}/complete" : {
+      "post" : {
+        "tags" : [ "Change property" ],
+        "summary" : "Mark a marketing event as completed",
+        "description" : "Mark a marketing event as completed",
+        "operationId" : "post-/events/{externalEventId}/complete_complete",
+        "parameters" : [ {
+          "name" : "externalEventId",
+          "in" : "path",
+          "description" : "The id of the marketing event in the external event application",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "externalAccountId",
+          "in" : "query",
+          "description" : "The accountId that is associated with this marketing event in the external event application",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MarketingEventCompleteRequestParams"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventDefaultResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/events" : {
+      "post" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Create a marketing event",
+        "description" : "Creates a new marketing event in HubSpot",
+        "operationId" : "post-/events_create",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MarketingEventCreateRequestParams"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MarketingEventDefaultResponse"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.write" ]
+        }, {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.write" ]
+        } ]
+      }
+    },
+    "/participations/contacts/{contactIdentifier}/breakdown" : {
+      "get" : {
+        "tags" : [ "Retrieve Participant State" ],
+        "summary" : "Read participations breakdown by Contact identifier",
+        "description" : "Read Contact's participations by identifier - email or internal id.",
+        "operationId" : "get-/participations/contacts/{contactIdentifier}/breakdown_getParticipationsBreakdownByContactId",
+        "parameters" : [ {
+          "name" : "contactIdentifier",
+          "in" : "path",
+          "description" : "The identifier of the Contact. It may be email or internal id",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "state",
+          "in" : "query",
+          "description" : "The participation state value. It may be REGISTERED, CANCELLED, ATTENDED, NO_SHOW",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The limit for response size. The default value is 10, the max number is 100",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The cursor indicating the position of the last retrieved item",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalParticipationBreakdownForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    },
+    "/{appId}/settings" : {
+      "get" : {
+        "tags" : [ "Settings" ],
+        "summary" : "Retrieve the application settings",
+        "description" : "Retrieve the current settings for the application.",
+        "operationId" : "get-/{appId}/settings_getAll",
+        "parameters" : [ {
+          "name" : "appId",
+          "in" : "path",
+          "description" : "The id of the application to retrieve the settings for",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EventDetailSettings"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Settings" ],
+        "summary" : "Update the application settings",
+        "description" : "Create or update the current settings for the application.",
+        "operationId" : "post-/{appId}/settings_update",
+        "parameters" : [ {
+          "name" : "appId",
+          "in" : "path",
+          "description" : "The id of the application to update the settings for",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/EventDetailSettingsUrl"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EventDetailSettings"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "developer_hapikey" : [ ]
+        } ]
+      }
+    },
+    "/events/search" : {
+      "get" : {
+        "tags" : [ "Identifiers" ],
+        "summary" : "Find App-Specific Marketing Events by External Event Id",
+        "description" : "Retrieves Marketing Events where the externalEventId matches the value provided in the request, limited to events created by the app making the request.\n\nMarketing Events created by other apps will not be included in the results.",
+        "operationId" : "get-/events/search_doSearch",
+        "parameters" : [ {
+          "name" : "q",
+          "in" : "query",
+          "description" : "The id of the marketing event in the external event application (externalEventId)",
+          "required" : true,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseSearchPublicResponseWrapperNoPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "crm.objects.marketing_events.read" ]
+        }, {
+          "private_apps_legacy" : [ "crm.objects.marketing_events.read" ]
+        } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "MarketingEventCompleteRequestParams" : {
+        "required" : [ "endDateTime", "startDateTime" ],
+        "type" : "object",
+        "properties" : {
+          "startDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "ParticipationProperties" : {
+        "required" : [ "attendanceState", "occurredAt" ],
+        "type" : "object",
+        "properties" : {
+          "occurredAt" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "attendancePercentage" : {
+            "type" : "string"
+          },
+          "attendanceState" : {
+            "type" : "string",
+            "enum" : [ "REGISTERED", "ATTENDED", "CANCELLED", "EMPTY", "NO_SHOW" ]
+          },
+          "attendanceDurationSeconds" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "SubscriberEmailResponse" : {
+        "required" : [ "email", "vid" ],
+        "type" : "object",
+        "properties" : {
+          "vid" : {
+            "type" : "integer"
+          },
+          "email" : {
+            "type" : "string"
+          }
+        }
+      },
+      "MarketingEventPublicReadResponse" : {
+        "required" : [ "attendees", "cancellations", "createdAt", "eventName", "eventOrganizer", "externalEventId", "id", "noShows", "registrants", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "registrants" : {
+            "type" : "integer",
+            "description" : "The number of HubSpot contacts that registered for this marketing event",
+            "format" : "int32"
+          },
+          "eventOrganizer" : {
+            "type" : "string",
+            "description" : "The name of the organizer of the marketing event"
+          },
+          "eventUrl" : {
+            "type" : "string",
+            "description" : "A URL in the external event application where the marketing event can be managed"
+          },
+          "attendees" : {
+            "type" : "integer",
+            "description" : "The number of HubSpot contacts that attended this marketing event",
+            "format" : "int32"
+          },
+          "eventType" : {
+            "type" : "string",
+            "description" : "The type of the marketing event"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "description" : "The end date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "noShows" : {
+            "type" : "integer",
+            "description" : "The number of HubSpot contacts that registered for this marketing event, but did not attend. This field only had a value when the event is over",
+            "format" : "int32"
+          },
+          "cancellations" : {
+            "type" : "integer",
+            "description" : "The number of HubSpot contacts that registered for this marketing event, but later cancelled their registration",
+            "format" : "int32"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          },
+          "startDateTime" : {
+            "type" : "string",
+            "description" : "The start date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "description" : "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean",
+            "description" : "Indicates if the marketing event has been cancelled"
+          },
+          "externalEventId" : {
+            "type" : "string",
+            "description" : "The id of the marketing event in the external event application"
+          },
+          "eventDescription" : {
+            "type" : "string",
+            "description" : "The description of the marketing event"
+          },
+          "eventName" : {
+            "type" : "string",
+            "description" : "The name of the marketing event"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "objectId" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          }
+        }
+      },
+      "MarketingEventAssociation" : {
+        "required" : [ "marketingEventId", "name" ],
+        "type" : "object",
+        "properties" : {
+          "externalAccountId" : {
+            "type" : "string"
+          },
+          "marketingEventId" : {
+            "type" : "string"
+          },
+          "externalEventId" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          }
+        }
+      },
+      "ErrorDetail" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "code" : {
+            "type" : "string",
+            "description" : "The status code associated with the error detail"
+          },
+          "in" : {
+            "type" : "string",
+            "description" : "The name of the field or parameter in which the error was found"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ]
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate"
+          }
+        }
+      },
+      "MarketingEventEmailSubscriber" : {
+        "required" : [ "email", "interactionDateTime" ],
+        "type" : "object",
+        "properties" : {
+          "contactProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "email" : {
+            "type" : "string",
+            "description" : "The email address of the contact in HubSpot to associate with the event"
+          },
+          "interactionDateTime" : {
+            "type" : "integer",
+            "description" : "Timestamp in milliseconds at which the contact subscribed to the event",
+            "format" : "int64"
+          }
+        }
+      },
+      "ForwardPaging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          }
+        }
+      },
+      "PublicList" : {
+        "required" : [ "listId", "listVersion", "name", "objectTypeId", "processingStatus", "processingType" ],
+        "type" : "object",
+        "properties" : {
+          "processingType" : {
+            "type" : "string"
+          },
+          "objectTypeId" : {
+            "type" : "string"
+          },
+          "updatedById" : {
+            "type" : "string"
+          },
+          "filtersUpdatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "listId" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "processingStatus" : {
+            "type" : "string"
+          },
+          "deletedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "listVersion" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "size" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "createdById" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "MarketingEventExternalUniqueIdentifier" : {
+        "required" : [ "appId", "externalAccountId", "externalEventId" ],
+        "type" : "object",
+        "properties" : {
+          "externalAccountId" : {
+            "type" : "string",
+            "description" : "The accountId that is associated with this marketing event in the external event application"
+          },
+          "externalEventId" : {
+            "type" : "string",
+            "description" : "The id of the marketing event in the external event application"
+          },
+          "appId" : {
+            "type" : "integer",
+            "description" : "The id of the application that created the marketing event in HubSpot",
+            "format" : "int32"
+          }
+        }
+      },
+      "CrmPropertyWrapper" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SearchPublicResponseWrapper" : {
+        "required" : [ "appId", "externalAccountId", "externalEventId", "objectId" ],
+        "type" : "object",
+        "properties" : {
+          "externalAccountId" : {
+            "type" : "string"
+          },
+          "externalEventId" : {
+            "type" : "string"
+          },
+          "appId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "objectId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SubscriberVidResponse" : {
+        "required" : [ "vid" ],
+        "type" : "object",
+        "properties" : {
+          "vid" : {
+            "type" : "integer"
+          }
+        }
+      },
+      "MarketingEventPublicUpdateRequestV2" : {
+        "required" : [ "customProperties" ],
+        "type" : "object",
+        "properties" : {
+          "startDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean"
+          },
+          "eventOrganizer" : {
+            "type" : "string"
+          },
+          "eventUrl" : {
+            "type" : "string"
+          },
+          "eventDescription" : {
+            "type" : "string"
+          },
+          "eventName" : {
+            "type" : "string"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "MarketingEventIdentifiersResponse" : {
+        "required" : [ "externalEventId", "marketingEventName", "objectId" ],
+        "type" : "object",
+        "properties" : {
+          "externalAccountId" : {
+            "type" : "string"
+          },
+          "externalEventId" : {
+            "type" : "string"
+          },
+          "appInfo" : {
+            "$ref" : "#/components/schemas/AppInfo"
+          },
+          "objectId" : {
+            "type" : "string"
+          },
+          "marketingEventName" : {
+            "type" : "string"
+          }
+        }
+      },
+      "PropertyValue" : {
+        "required" : [ "dataSensitivity", "isEncrypted", "name", "requestId", "selectedByUser", "selectedByUserTimestamp", "source", "sourceId", "sourceLabel", "sourceMetadata", "sourceVid", "timestamp", "unit", "value" ],
+        "type" : "object",
+        "properties" : {
+          "sourceId" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "selectedByUser" : {
+            "type" : "boolean",
+            "description" : ""
+          },
+          "sourceLabel" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "source" : {
+            "type" : "string",
+            "description" : "",
+            "enum" : [ "UNKNOWN", "IMPORT", "API", "FORM", "ANALYTICS", "MIGRATION", "SALESFORCE", "INTEGRATION", "CONTACTS_WEB", "WAL_INCREMENTAL", "TASK", "EMAIL", "WORKFLOWS", "CALCULATED", "SOCIAL", "BATCH_UPDATE", "SIGNALS", "BIDEN", "DEFAULT", "COMPANIES", "DEALS", "ASSISTS", "PRESENTATIONS", "TALLY", "SIDEKICK", "CRM_UI", "MERGE_CONTACTS", "PORTAL_USER_ASSOCIATOR", "INTEGRATIONS_PLATFORM", "BCC_TO_CRM", "FORWARD_TO_CRM", "ENGAGEMENTS", "SALES", "HEISENBERG", "LEADIN", "GMAIL_INTEGRATION", "ACADEMY", "SALES_MESSAGES", "AVATARS_SERVICE", "MERGE_COMPANIES", "SEQUENCES", "COMPANY_FAMILIES", "MOBILE_IOS", "MOBILE_ANDROID", "CONTACTS", "ASSOCIATIONS", "EXTENSION", "SUCCESS", "BOT", "INTEGRATIONS_SYNC", "AUTOMATION_PLATFORM", "CONVERSATIONS", "EMAIL_INTEGRATION", "CONTENT_MEMBERSHIP", "QUOTES", "BET_ASSIGNMENT", "QUOTAS", "BET_CRM_CONNECTOR", "MEETINGS", "MERGE_OBJECTS", "RECYCLING_BIN", "ADS", "AI_GROUP", "COMMUNICATOR", "SETTINGS", "PROPERTY_SETTINGS", "PIPELINE_SETTINGS", "COMPANY_INSIGHTS", "BEHAVIORAL_EVENTS", "PAYMENTS", "GOALS", "PORTAL_OBJECT_SYNC", "APPROVALS", "FILE_MANAGER", "MARKETPLACE", "INTERNAL_PROCESSING", "FORECASTING", "SLACK_INTEGRATION", "CRM_UI_BULK_ACTION", "WORKFLOW_CONTACT_DELETE_ACTION", "ACCEPTANCE_TEST", "PLAYBOOKS", "CHATSPOT", "FLYWHEEL_PRODUCT_DATA_SYNC", "HELP_DESK", "BILLING", "DATA_ENRICHMENT", "AUTOMATION_JOURNEY", "MICROAPPS", "INTENT", "PROSPECTING_AGENT", "CENTRAL_EXCHANGE_RATES" ]
+          },
+          "updatedByUserId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "persistenceTimestamp" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "sourceMetadata" : {
+            "type" : "string",
+            "description" : "Source metadata encoded as a base64 string. For example: `ZXhhbXBsZSBzdHJpbmc=`"
+          },
+          "dataSensitivity" : {
+            "type" : "string",
+            "enum" : [ "none", "standard", "high" ]
+          },
+          "sourceVid" : {
+            "type" : "array",
+            "description" : "",
+            "items" : {
+              "type" : "integer",
+              "format" : "int64"
+            }
+          },
+          "unit" : {
+            "type" : "string"
+          },
+          "requestId" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "isEncrypted" : {
+            "type" : "boolean"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "useTimestampAsPersistenceTimestamp" : {
+            "type" : "boolean"
+          },
+          "value" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "selectedByUserTimestamp" : {
+            "type" : "integer",
+            "description" : "",
+            "format" : "int64"
+          },
+          "timestamp" : {
+            "type" : "integer",
+            "description" : "",
+            "format" : "int64"
+          },
+          "isLargeValue" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "BatchInputMarketingEventExternalUniqueIdentifier" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventExternalUniqueIdentifier"
+            }
+          }
+        }
+      },
+      "MarketingEventUpdateRequestParams" : {
+        "type" : "object",
+        "properties" : {
+          "startDateTime" : {
+            "type" : "string",
+            "description" : "The start date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "description" : "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean",
+            "description" : "Indicates if the marketing event has been cancelled. Defaults to `false`"
+          },
+          "eventOrganizer" : {
+            "type" : "string",
+            "description" : "The name of the organizer of the marketing event"
+          },
+          "eventUrl" : {
+            "type" : "string",
+            "description" : "A URL in the external event application where the marketing event can be managed"
+          },
+          "eventDescription" : {
+            "type" : "string",
+            "description" : "The description of the marketing event"
+          },
+          "eventName" : {
+            "type" : "string",
+            "description" : "The name of the marketing event"
+          },
+          "eventType" : {
+            "type" : "string",
+            "description" : "Describes what type of event this is.  For example: `WEBINAR`, `CONFERENCE`, `WORKSHOP`"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "description" : "The end date and time of the marketing event",
+            "format" : "datetime"
+          }
+        }
+      },
+      "AppInfo" : {
+        "required" : [ "id", "name" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CollectionResponseWithTotalPublicListNoPaging" : {
+        "required" : [ "results", "total" ],
+        "type" : "object",
+        "properties" : {
+          "total" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicList"
+            }
+          }
+        }
+      },
+      "ContactAssociation" : {
+        "required" : [ "contactId", "email" ],
+        "type" : "object",
+        "properties" : {
+          "firstname" : {
+            "type" : "string"
+          },
+          "contactId" : {
+            "type" : "string"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "lastname" : {
+            "type" : "string"
+          }
+        }
+      },
+      "ParticipationBreakdown" : {
+        "required" : [ "associations", "createdAt", "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "$ref" : "#/components/schemas/ParticipationAssociations"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "$ref" : "#/components/schemas/ParticipationProperties"
+          }
+        }
+      },
+      "MarketingEventPublicDefaultResponse" : {
+        "required" : [ "createdAt", "eventName", "eventOrganizer", "id", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "eventOrganizer" : {
+            "type" : "string",
+            "description" : "The name of the organizer of the marketing event"
+          },
+          "eventUrl" : {
+            "type" : "string",
+            "description" : "A URL in the external event application where the marketing event can be managed"
+          },
+          "eventType" : {
+            "type" : "string",
+            "description" : "The type of the marketing event"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "description" : "The end date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          },
+          "startDateTime" : {
+            "type" : "string",
+            "description" : "The start date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "description" : "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean",
+            "description" : "Indicates if the marketing event has been cancelled"
+          },
+          "eventDescription" : {
+            "type" : "string",
+            "description" : "The description of the marketing event"
+          },
+          "eventName" : {
+            "type" : "string",
+            "description" : "The name of the marketing event"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "objectId" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          }
+        }
+      },
+      "BatchResponseSubscriberVidResponse" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SubscriberVidResponse"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "MarketingEventDefaultResponse" : {
+        "required" : [ "eventName", "eventOrganizer" ],
+        "type" : "object",
+        "properties" : {
+          "startDateTime" : {
+            "type" : "string",
+            "description" : "The start date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "description" : "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean",
+            "description" : "Indicates if the marketing event has been cancelled"
+          },
+          "eventOrganizer" : {
+            "type" : "string",
+            "description" : "The name of the organizer of the marketing event"
+          },
+          "eventUrl" : {
+            "type" : "string",
+            "description" : "The URL in the external event application where the marketing event can be managed"
+          },
+          "eventDescription" : {
+            "type" : "string",
+            "description" : "The description of the marketing event"
+          },
+          "eventName" : {
+            "type" : "string",
+            "description" : "The name of the marketing event"
+          },
+          "eventType" : {
+            "type" : "string",
+            "description" : "The type of the marketing event"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "description" : "The end date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "objectId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "ParticipationAssociations" : {
+        "required" : [ "contact", "marketingEvent" ],
+        "type" : "object",
+        "properties" : {
+          "marketingEvent" : {
+            "$ref" : "#/components/schemas/MarketingEventAssociation"
+          },
+          "contact" : {
+            "$ref" : "#/components/schemas/ContactAssociation"
+          }
+        }
+      },
+      "BatchInputMarketingEventSubscriber" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "description" : "List of HubSpot contacts to subscribe to the marketing event",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventSubscriber"
+            }
+          }
+        }
+      },
+      "StandardError" : {
+        "required" : [ "category", "context", "errors", "links", "message", "status" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "object",
+            "properties" : { },
+            "description" : ""
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : ""
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : ""
+          },
+          "id" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "category" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "message" : {
+            "type" : "string",
+            "description" : ""
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "description" : ""
+          }
+        }
+      },
+      "MarketingEventCreateRequestParams" : {
+        "required" : [ "eventName", "eventOrganizer", "externalAccountId", "externalEventId" ],
+        "type" : "object",
+        "properties" : {
+          "startDateTime" : {
+            "type" : "string",
+            "description" : "The start date and time of the marketing event",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "description" : "A list of PropertyValues. These can be whatever kind of property names and values you want. However, they must already exist on the HubSpot account's definition of the MarketingEvent Object. If they don't they will be filtered out and not set.\nIn order to do this you'll need to create a new PropertyGroup on the HubSpot account's MarketingEvent object for your specific app and create the Custom Property you want to track on that HubSpot account. Do not create any new default properties on the MarketingEvent object as that will apply to all HubSpot accounts\n",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "externalAccountId" : {
+            "type" : "string",
+            "description" : "The accountId that is associated with this marketing event in the external event application"
+          },
+          "eventCancelled" : {
+            "type" : "boolean",
+            "description" : "Indicates if the marketing event has been cancelled.  Defaults to `false`"
+          },
+          "eventOrganizer" : {
+            "type" : "string",
+            "description" : "The name of the organizer of the marketing event"
+          },
+          "eventUrl" : {
+            "type" : "string",
+            "description" : "A URL in the external event application where the marketing event can be managed"
+          },
+          "externalEventId" : {
+            "type" : "string",
+            "description" : "The id of the marketing event in the external event application"
+          },
+          "eventDescription" : {
+            "type" : "string",
+            "description" : "The description of the marketing event"
+          },
+          "eventName" : {
+            "type" : "string",
+            "description" : "The name of the marketing event"
+          },
+          "eventType" : {
+            "type" : "string",
+            "description" : "Describes what type of event this is.  For example: `WEBINAR`, `CONFERENCE`, `WORKSHOP`"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "description" : "The end date and time of the marketing event",
+            "format" : "datetime"
+          }
+        }
+      },
+      "BatchInputMarketingEventPublicUpdateRequestFullV2" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventPublicUpdateRequestFullV2"
+            }
+          }
+        }
+      },
+      "CollectionResponseWithTotalMarketingEventIdentifiersResponseNoPaging" : {
+        "required" : [ "results", "total" ],
+        "type" : "object",
+        "properties" : {
+          "total" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventIdentifiersResponse"
+            }
+          }
+        }
+      },
+      "EventDetailSettings" : {
+        "required" : [ "appId", "eventDetailsUrl" ],
+        "type" : "object",
+        "properties" : {
+          "appId" : {
+            "type" : "integer",
+            "description" : "The id of the application the settings are for",
+            "format" : "int32"
+          },
+          "eventDetailsUrl" : {
+            "type" : "string",
+            "description" : "The url that will be used to fetch marketing event details by id"
+          }
+        }
+      },
+      "MarketingEventSubscriber" : {
+        "required" : [ "interactionDateTime", "vid" ],
+        "type" : "object",
+        "properties" : {
+          "vid" : {
+            "type" : "integer"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "interactionDateTime" : {
+            "type" : "integer",
+            "description" : "Timestamp in milliseconds at which the contact subscribed to the event",
+            "format" : "int64"
+          }
+        }
+      },
+      "EventDetailSettingsUrl" : {
+        "required" : [ "eventDetailsUrl" ],
+        "type" : "object",
+        "properties" : {
+          "eventDetailsUrl" : {
+            "type" : "string",
+            "description" : "The url that will be used to fetch marketing event details by id. Must contain a `%s` character sequence that will be substituted with the event id. For example: `https://my.event.app/events/%s`"
+          }
+        }
+      },
+      "BatchInputMarketingEventEmailSubscriber" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "description" : "List of marketing event details to create or update",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventEmailSubscriber"
+            }
+          }
+        }
+      },
+      "CollectionResponseMarketingEventPublicReadResponseV2ForwardPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventPublicReadResponseV2"
+            }
+          }
+        }
+      },
+      "MarketingEventPublicDefaultResponseV2" : {
+        "required" : [ "createdAt", "customProperties", "eventName", "objectId", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "eventOrganizer" : {
+            "type" : "string"
+          },
+          "eventUrl" : {
+            "type" : "string"
+          },
+          "appInfo" : {
+            "$ref" : "#/components/schemas/AppInfo"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean"
+          },
+          "eventDescription" : {
+            "type" : "string"
+          },
+          "eventName" : {
+            "type" : "string"
+          },
+          "objectId" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "MarketingEventPublicUpdateRequestFullV2" : {
+        "required" : [ "customProperties", "objectId" ],
+        "type" : "object",
+        "properties" : {
+          "startDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean"
+          },
+          "eventOrganizer" : {
+            "type" : "string"
+          },
+          "eventUrl" : {
+            "type" : "string"
+          },
+          "eventDescription" : {
+            "type" : "string"
+          },
+          "eventName" : {
+            "type" : "string"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "objectId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "MarketingEventPublicReadResponseV2" : {
+        "required" : [ "createdAt", "customProperties", "eventName", "objectId", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "registrants" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "eventOrganizer" : {
+            "type" : "string"
+          },
+          "eventUrl" : {
+            "type" : "string"
+          },
+          "attendees" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "appInfo" : {
+            "$ref" : "#/components/schemas/AppInfo"
+          },
+          "eventType" : {
+            "type" : "string"
+          },
+          "eventCompleted" : {
+            "type" : "boolean"
+          },
+          "endDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "noShows" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "cancellations" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startDateTime" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "customProperties" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CrmPropertyWrapper"
+            }
+          },
+          "eventCancelled" : {
+            "type" : "boolean"
+          },
+          "externalEventId" : {
+            "type" : "string"
+          },
+          "eventStatus" : {
+            "type" : "string"
+          },
+          "eventDescription" : {
+            "type" : "string"
+          },
+          "eventName" : {
+            "type" : "string"
+          },
+          "objectId" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "BatchInputMarketingEventCreateRequestParams" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "description" : "",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventCreateRequestParams"
+            }
+          }
+        }
+      },
+      "BatchResponseMarketingEventPublicDefaultResponseV2WithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventPublicDefaultResponseV2"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "Error" : {
+        "required" : [ "category", "correlationId", "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ],
+              "invalidPropertyName" : [ "propertyValue" ]
+            }
+          },
+          "correlationId" : {
+            "type" : "string",
+            "description" : "A unique identifier for the request. Include this value with any error reports or support tickets",
+            "format" : "uuid",
+            "example" : "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+            "example" : {
+              "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate",
+            "example" : "Invalid input (details will vary based on the error)"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "The error category",
+            "example" : "VALIDATION_ERROR"
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "further information about the error",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          }
+        },
+        "example" : {
+          "message" : "Invalid input (details will vary based on the error)",
+          "correlationId" : "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+          "category" : "VALIDATION_ERROR",
+          "links" : {
+            "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+          }
+        }
+      },
+      "BatchInputMarketingEventPublicObjectIdDeleteRequest" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventPublicObjectIdDeleteRequest"
+            }
+          }
+        }
+      },
+      "CollectionResponseSearchPublicResponseWrapperNoPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SearchPublicResponseWrapper"
+            }
+          }
+        }
+      },
+      "AttendanceCounters" : {
+        "required" : [ "attended", "cancelled", "noShows", "registered" ],
+        "type" : "object",
+        "properties" : {
+          "attended" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "registered" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "cancelled" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "noShows" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "BatchResponseSubscriberEmailResponse" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SubscriberEmailResponse"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "MarketingEventPublicObjectIdDeleteRequest" : {
+        "required" : [ "objectId" ],
+        "type" : "object",
+        "properties" : {
+          "objectId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CollectionResponseWithTotalParticipationBreakdownForwardPaging" : {
+        "required" : [ "results", "total" ],
+        "type" : "object",
+        "properties" : {
+          "total" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ParticipationBreakdown"
+            }
+          }
+        }
+      },
+      "BatchResponseMarketingEventPublicDefaultResponseV2" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventPublicDefaultResponseV2"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "NextPage" : {
+        "required" : [ "after" ],
+        "type" : "object",
+        "properties" : {
+          "link" : {
+            "type" : "string"
+          },
+          "after" : {
+            "type" : "string"
+          }
+        }
+      },
+      "BatchResponseMarketingEventPublicDefaultResponse" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "description" : "",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "description" : "",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : ""
+          },
+          "results" : {
+            "type" : "array",
+            "description" : "",
+            "items" : {
+              "$ref" : "#/components/schemas/MarketingEventPublicDefaultResponse"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "description" : "",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      }
+    },
+    "responses" : {
+      "Error" : {
+        "description" : "An error occurred",
+        "content" : {
+          "*/*" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "oauth2_legacy" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.marketing_events.read" : "Read marketing events",
+              "crm.objects.marketing_events.write" : "Write marketing events"
+            }
+          }
+        }
+      },
+      "developer_hapikey" : {
+        "type" : "apiKey",
+        "name" : "hapikey",
+        "in" : "query"
+      },
+      "private_apps_legacy" : {
+        "type" : "apiKey",
+        "name" : "private-app-legacy",
+        "in" : "header",
+        "x-ballerina-name" : "privateAppLegacy"
+      }
+    }
+  },
+  "x-hubspot-available-client-libraries" : [ "PHP", "Node", "Ruby", "Python" ],
+  "x-hubspot-product-tier-requirements" : {
+    "marketing" : "FREE",
+    "cms" : "STARTER"
+  },
+  "x-hubspot-documentation-banner" : "PUBLIC_BETA"
+}

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,7 +1,7 @@
 
 _Author_: @Sadeesha-Sath \
 _Created_: 2025/01/02 \
-_Updated_: 2025/01/02 \
+_Updated_: 2026/06/18 \\
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,7 +1,7 @@
 
 _Author_: @Sadeesha-Sath \
 _Created_: 2025/01/02 \
-_Updated_: 2026/06/18 \\
+_Updated_: 2026/06/18 \
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification


### PR DESCRIPTION
Improve operation summaries and add field descriptions

## Purpose

The Ballerina client generator builds doc comments solely from the OpenAPI `summary` field. Previously, only `description` was AI-improved, leaving `summary` fields as terse single words (e.g. "Read", "Archive", "Update") that produced unhelpful doc comments. This PR improves the developer experience by replacing those with concise, meaningful action phrases and adding field-level descriptions to generated types.

Fixes [wso2/product-integrator#1701](https://github.com/wso2/product-integrator/issues/1701)

## Changes

- Replace terse single-word operation summaries in `client.bal` with concise action phrases that accurately describe each operation, e.g. "Read" → "Retrieve a record by ID", "Archive" → "Archive a record by ID", "Update" → "Update a record by ID", "List" → "Retrieve a page of records".

- Condense any overlong summaries to fit the 35-character doc-comment cap.

- Add missing summaries where absent (e.g. search operations).

- Add AI-generated field-level descriptions to `types.bal` to improve generated documentation.

- Refresh `sanitations.md` with updated regeneration timestamp and add `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec artifacts.

## Examples

**Before:**
```ballerina
# Read
resource isolated function get records/[string recordId](...) { }

# Archive
resource isolated function delete records/[string recordId](...) { }

# Update
resource isolated function patch records/[string recordId](...) { }
```

**After:**
```ballerina
# Retrieve a record by ID
resource isolated function get records/[string recordId](...) { }

# Archive a record by ID
resource isolated function delete records/[string recordId](...) { }

# Update a record by ID
resource isolated function patch records/[string recordId](...) { }
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
