### PR TITLE
chore: sync main after 1.0.1 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.0.1-SNAPSHOT
+version=1.0.1
 
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.0.1
+version=1.0.2-SNAPSHOT
 
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0


### PR DESCRIPTION
## Purpose

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the project version in `gradle.properties` from `1.0.1-SNAPSHOT` to `1.0.2-SNAPSHOT` to advance the codebase to the next development cycle after the release sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->